### PR TITLE
fix: Updates would not be displayed without restarting the app

### DIFF
--- a/core/BookmarksCore/Common/BookmarksManager.swift
+++ b/core/BookmarksCore/Common/BookmarksManager.swift
@@ -50,13 +50,12 @@ public class BookmarksManager {
         thumbnailManager = ThumbnailManager(imageCache: imageCache, downloadManager: downloadManager)
         updater = Updater(store: store, token: settings.pinboardApiKey)
 
-        #if targetEnvironment(macCatalyst)
+        #if os(macOS)
         let notificationCenter = NotificationCenter.default
         notificationCenter.addObserver(self, selector: #selector(nsApplicationDidBecomeActive),
                                        name: NSNotification.Name("NSApplicationDidBecomeActiveNotification"),
                                        object: nil)
         #endif
-
     }
 
     @objc

--- a/macos/Bookmarks/BookmarksApp.swift
+++ b/macos/Bookmarks/BookmarksApp.swift
@@ -23,29 +23,17 @@ import SwiftUI
 
 import BookmarksCore
 
-class AppDelegate: NSObject, NSApplicationDelegate {
-
-    var manager = BookmarksManager()
-
-    func applicationDidBecomeActive(_ notification: Notification) {
-        manager.updater.start()
-    }
-}
-
 @main
 struct BookmarksApp: App {
 
-    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @Environment(\.manager) var manager: BookmarksManager
 
     var body: some Scene {
         WindowGroup {
             ContentView(store: manager.store)
-                .environment(\.manager, appDelegate.manager)
         }
         SwiftUI.Settings {
             SettingsView()
-                .environment(\.manager, appDelegate.manager)
         }
     }
 }


### PR DESCRIPTION
Two `BookmarksManager` instances were being initialized at app startup; one was being used for display, and the other was processing the updates, meaning that the UI was never notified of the updates.