### PR TITLE
ci: Use the correct parameter for executing the changes release command

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -204,6 +204,6 @@ if $RELEASE ; then
         release \
         --skip-if-empty \
         --push \
-        --command "${CHANGES_GITHUB_RELEASE_SCRIPT}" \
+        --exec "${CHANGES_GITHUB_RELEASE_SCRIPT}" \
         "${BUILD_DIRECTORY}/${ZIP_BASENAME}"
 fi


### PR DESCRIPTION
A previous change partially updated the call to `changes release` but failed to switch from using the `--command` flag to `--exec`.