### PR TITLE
feat: Navigate to tags from the bookmarks context menu

### DIFF
--- a/core/BookmarksCore/Store/Database.swift
+++ b/core/BookmarksCore/Store/Database.swift
@@ -93,7 +93,7 @@ extension String {
 public struct ItemFilter {
 
     var tags: Set<String>? = nil
-    var terms: [String] = []  // Maybe this should be a set too?
+    var terms: [String] = []
 
     init(tags: Set<String>?, terms: [String]) {
         self.tags = tags

--- a/core/BookmarksCore/Store/Database.swift
+++ b/core/BookmarksCore/Store/Database.swift
@@ -120,8 +120,6 @@ public struct ItemFilter {
     }
 
     static func &&(lhs: Self, rhs: Self) -> Self {
-        // TODO: What happens when you and empty tags and non-empty tags. Technically it should always fail?
-        // There's almost certainly a more elegant reduce operation that could be performed here.
         var tags: Set<String>? = nil
         if let lhs_tags = lhs.tags,
            let rhs_tags = rhs.tags {

--- a/core/BookmarksCore/Store/Database.swift
+++ b/core/BookmarksCore/Store/Database.swift
@@ -543,7 +543,6 @@ public class Database {
         return items(filter: filter.terms.joined(separator: " "), tags: queryTags, completion: completion)
     }
 
-    // TODO: Consider removing this API
     public func items(filter: String? = nil, tags: [String]? = nil, completion: @escaping (Swift.Result<[Item], Error>) -> Void) {
         let completion = DispatchQueue.global().asyncClosure(completion)
         syncQueue.async {

--- a/core/BookmarksCore/Store/DatabaseView.swift
+++ b/core/BookmarksCore/Store/DatabaseView.swift
@@ -21,6 +21,7 @@
 import Combine
 import Foundation
 
+// TODO: Rename this to ItemView
 public class DatabaseView: ObservableObject {
 
     let database: Database
@@ -30,10 +31,10 @@ public class DatabaseView: ObservableObject {
     @Published public var search = ""
     @Published public var items: [Item] = []
 
-    fileprivate var tags: [String]?
+    fileprivate var tags: Set<String>?
     fileprivate var filter = ""
 
-    public init(database: Database, tags: [String]? = nil) {
+    public init(database: Database, tags: Set<String>? = nil) {
         self.database = database
         self.tags = tags
     }
@@ -41,7 +42,8 @@ public class DatabaseView: ObservableObject {
     func update() {
         dispatchPrecondition(condition: .onQueue(.main))
         print("fetching items...")
-        database.items(filter: filter, tags: tags) { result in
+
+        database.items(ItemFilter(tags: tags, terms: []) && ItemFilter(filter: filter)) { result in
             DispatchQueue.main.async {
                 switch result {
                 case .success(let items):

--- a/core/BookmarksCore/Store/DatabaseView.swift
+++ b/core/BookmarksCore/Store/DatabaseView.swift
@@ -21,7 +21,6 @@
 import Combine
 import Foundation
 
-// TODO: Rename this to ItemView
 public class DatabaseView: ObservableObject {
 
     let database: Database

--- a/macos/Bookmarks-macOS.xcodeproj/project.pbxproj
+++ b/macos/Bookmarks-macOS.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		D861257326A60DF200EB5FEF /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D861257226A60DF200EB5FEF /* Sidebar.swift */; };
 		D861257526AA048E00EB5FEF /* RenameTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D861257426AA048E00EB5FEF /* RenameTagView.swift */; };
 		D861257A26AB72D000EB5FEF /* BookmarksSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D861257926AB72D000EB5FEF /* BookmarksSection.swift */; };
+		D861257C26AB741A00EB5FEF /* SidebarLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = D861257B26AB741A00EB5FEF /* SidebarLink.swift */; };
 		D891C454261E32F90024E1A6 /* BookmarksApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D891C453261E32F90024E1A6 /* BookmarksApp.swift */; };
 		D891C456261E32F90024E1A6 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D891C455261E32F90024E1A6 /* ContentView.swift */; };
 		D891C458261E32FB0024E1A6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D891C457261E32FB0024E1A6 /* Assets.xcassets */; };
@@ -64,6 +65,7 @@
 		D861257226A60DF200EB5FEF /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
 		D861257426AA048E00EB5FEF /* RenameTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameTagView.swift; sourceTree = "<group>"; };
 		D861257926AB72D000EB5FEF /* BookmarksSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksSection.swift; sourceTree = "<group>"; };
+		D861257B26AB741A00EB5FEF /* SidebarLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarLink.swift; sourceTree = "<group>"; };
 		D891C450261E32F90024E1A6 /* Bookmarks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bookmarks.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D891C453261E32F90024E1A6 /* BookmarksApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksApp.swift; sourceTree = "<group>"; };
 		D891C455261E32F90024E1A6 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -190,6 +192,7 @@
 				D840B0092621042B001E95D1 /* SettingsView.swift */,
 				D861257226A60DF200EB5FEF /* Sidebar.swift */,
 				D861257426AA048E00EB5FEF /* RenameTagView.swift */,
+				D861257B26AB741A00EB5FEF /* SidebarLink.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -353,6 +356,7 @@
 				D840B00A2621042B001E95D1 /* SettingsView.swift in Sources */,
 				D891C454261E32F90024E1A6 /* BookmarksApp.swift in Sources */,
 				D8B04B40261F49F100376ADD /* BookmarkCell.swift in Sources */,
+				D861257C26AB741A00EB5FEF /* SidebarLink.swift in Sources */,
 				D861257A26AB72D000EB5FEF /* BookmarksSection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/macos/Bookmarks-macOS.xcodeproj/project.pbxproj
+++ b/macos/Bookmarks-macOS.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		D840B01226210AF6001E95D1 /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D840B01126210AF6001E95D1 /* GeneralSettingsView.swift */; };
 		D861257326A60DF200EB5FEF /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D861257226A60DF200EB5FEF /* Sidebar.swift */; };
 		D861257526AA048E00EB5FEF /* RenameTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D861257426AA048E00EB5FEF /* RenameTagView.swift */; };
+		D861257A26AB72D000EB5FEF /* BookmarksSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D861257926AB72D000EB5FEF /* BookmarksSection.swift */; };
 		D891C454261E32F90024E1A6 /* BookmarksApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D891C453261E32F90024E1A6 /* BookmarksApp.swift */; };
 		D891C456261E32F90024E1A6 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D891C455261E32F90024E1A6 /* ContentView.swift */; };
 		D891C458261E32FB0024E1A6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D891C457261E32FB0024E1A6 /* Assets.xcassets */; };
@@ -62,6 +63,7 @@
 		D840B01126210AF6001E95D1 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		D861257226A60DF200EB5FEF /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
 		D861257426AA048E00EB5FEF /* RenameTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameTagView.swift; sourceTree = "<group>"; };
+		D861257926AB72D000EB5FEF /* BookmarksSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksSection.swift; sourceTree = "<group>"; };
 		D891C450261E32F90024E1A6 /* Bookmarks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bookmarks.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D891C453261E32F90024E1A6 /* BookmarksApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksApp.swift; sourceTree = "<group>"; };
 		D891C455261E32F90024E1A6 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 				D8B6E2C3262098FB00B2C239 /* Extensions */,
 				D8B04B43261F4A1200376ADD /* Views */,
 				D891C453261E32F90024E1A6 /* BookmarksApp.swift */,
+				D861257926AB72D000EB5FEF /* BookmarksSection.swift */,
 				D891C457261E32FB0024E1A6 /* Assets.xcassets */,
 				D891C45D261E32FB0024E1A6 /* Bookmarks.entitlements */,
 				D891C45C261E32FB0024E1A6 /* Info.plist */,
@@ -350,6 +353,7 @@
 				D840B00A2621042B001E95D1 /* SettingsView.swift in Sources */,
 				D891C454261E32F90024E1A6 /* BookmarksApp.swift in Sources */,
 				D8B04B40261F49F100376ADD /* BookmarkCell.swift in Sources */,
+				D861257A26AB72D000EB5FEF /* BookmarksSection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/Bookmarks/BookmarksSection.swift
+++ b/macos/Bookmarks/BookmarksSection.swift
@@ -1,0 +1,58 @@
+// Copyright (c) 2020-2021 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftUI
+
+enum BookmarksSection {
+    case all
+    case untagged
+    case favorite(tag: String)
+    case tag(tag: String)
+}
+
+extension BookmarksSection: CustomStringConvertible, Hashable, Identifiable {
+
+    var id: String { String(describing: self) }
+
+    var description: String {
+        switch self {
+        case .all:
+            return "uk.co.inseven.bookmarks.all-bookmarks"
+        case .untagged:
+            return "uk.co.inseven.bookmarks.untagged"
+        case .favorite(let tag):
+            return "uk.co.inseven.bookmarks.favorites.\(tag)"
+        case .tag(let tag):
+            return "uk.co.inseven.bookmarks.tags.\(tag)"
+        }
+    }
+
+}
+
+struct FocusedMessageKey : FocusedValueKey {
+        typealias Value = Binding<BookmarksSection?>
+}
+
+extension FocusedValues {
+    var sidebarSelection: FocusedMessageKey.Value? {
+        get { self[FocusedMessageKey.self] }
+        set { self[FocusedMessageKey.self] = newValue }
+    }
+}

--- a/macos/Bookmarks/Views/BookmarkCell.swift
+++ b/macos/Bookmarks/Views/BookmarkCell.swift
@@ -61,7 +61,6 @@ struct BookmarkCell: View {
                         .frame(maxWidth: image.size.width, maxHeight: image.size.height)
                         .background(Color.white)
                         .layoutPriority(-1)
-//                        .transition(AnyTransition.opacity.animation(.easeInOut(duration: 0.3)))
             }
         }
         .clipped()

--- a/macos/Bookmarks/Views/ContentView.swift
+++ b/macos/Bookmarks/Views/ContentView.swift
@@ -26,7 +26,7 @@ import Interact
 
 struct ContentView: View {
 
-    @Binding var sidebarSelection: Tags?
+    @Binding var sidebarSelection: BookmarksSection?
 
     @Environment(\.manager) var manager: BookmarksManager
     @StateObject var databaseView: DatabaseView

--- a/macos/Bookmarks/Views/ContentView.swift
+++ b/macos/Bookmarks/Views/ContentView.swift
@@ -26,6 +26,8 @@ import Interact
 
 struct ContentView: View {
 
+    @Binding var sidebarSelection: Tags?
+
     @Environment(\.manager) var manager: BookmarksManager
     @StateObject var databaseView: DatabaseView
 
@@ -88,7 +90,7 @@ struct ContentView: View {
                                     Menu("Tags") {
                                         ForEach(Array(item.tags).sorted()) { tag in
                                             Button(tag) {
-                                                print(item.tags)
+                                                sidebarSelection = tag.tagId
                                             }
                                         }
                                     }

--- a/macos/Bookmarks/Views/ContentView.swift
+++ b/macos/Bookmarks/Views/ContentView.swift
@@ -74,6 +74,7 @@ struct ContentView: View {
                                     NSPasteboard.general.setString(item.url.absoluteString, forType: .string)
                                 }
                                 Button("Delete") {
+                                    manager.database.delete(identifier: item.identifier) { _ in }
                                     manager.pinboard.posts_delete(url: item.url) { result in
                                         switch result {
                                         case .success:

--- a/macos/Bookmarks/Views/Sidebar.swift
+++ b/macos/Bookmarks/Views/Sidebar.swift
@@ -24,46 +24,7 @@ import SwiftUI
 import BookmarksCore
 import Interact
 
-extension String {
-
-    var favoriteId: BookmarksSection { .favorite(tag: self) }
-    var tagId: BookmarksSection { .tag(tag: self) }
-
-}
-
-struct SidebarLink: View {
-
-    var selection: Binding<BookmarksSection?>
-    var tag: BookmarksSection
-    var title: String
-    var systemImage: String
-    var databaseView: DatabaseView
-
-    func selectionActiveBinding(_ tag: BookmarksSection) -> Binding<Bool> {
-        return Binding {
-            selection.wrappedValue == tag
-        } set: { value in
-            guard value == true else {
-                return
-            }
-            selection.wrappedValue = tag
-        }
-    }
-
-    var body: some View {
-        NavigationLink(destination: ContentView(sidebarSelection: selection, databaseView: databaseView)
-                        .navigationTitle(title),
-                       isActive: selectionActiveBinding(tag)) {
-            Label(title, systemImage: systemImage)
-        }
-        .tag(tag)
-    }
-
-}
-
 struct Sidebar: View {
-
-    // TOOD: Maybe the sidebar selection is an app manager thing, given it's probably top-level app state?
 
     enum SheetType {
         case rename(tag: String)
@@ -88,88 +49,97 @@ struct Sidebar: View {
     }
 
     var body: some View {
-        List(selection: $selection) {
-            Section {
-
-                SidebarLink(selection: $selection,
-                            tag: .all,
-                            title: "All Bookmarks",
-                            systemImage: "bookmark",
-                            databaseView: DatabaseView(database: manager.database))
-
-                SidebarLink(selection: $selection,
-                            tag: .untagged,
-                            title: "Untagged",
-                            systemImage: "tag",
-                            databaseView: DatabaseView(database: manager.database))
-
-            }
-            Section(header: Text("Favourites")) {
-                ForEach(settings.favoriteTags.sorted(), id: \.favoriteId) { tag in
+        ScrollViewReader { scrollView in
+            List(selection: $selection) {
+                Section {
 
                     SidebarLink(selection: $selection,
-                                tag: tag.favoriteId,
-                                title: tag,
-                                systemImage: "tag",
-                                databaseView: DatabaseView(database: manager.database, tags: [tag]))
-                        .contextMenu(ContextMenu(menuItems: {
-                            Button("Remove from Favourites") {
-                                settings.favoriteTags = settings.favoriteTags.filter { $0 != tag }
-                            }
-                            Divider()
-                            Button("Edit on Pinboard") {
-                                do {
-                                    guard let user = manager.user else {
-                                        return
-                                    }
-                                    NSWorkspace.shared.open(try tag.pinboardUrl(for: user))
-                                } catch {
-                                    print("Failed to open on Pinboard error \(error)")
-                                }
-                            }
-                        }))
-
-                }
-            }
-            Section(header: Text("Tags")) {
-                ForEach(tagsView.tags, id: \.tagId) { tag in
+                                tag: .all,
+                                title: "All Bookmarks",
+                                systemImage: "bookmark",
+                                databaseView: DatabaseView(database: manager.database))
 
                     SidebarLink(selection: $selection,
-                                tag: tag.tagId,
-                                title: tag,
+                                tag: .untagged,
+                                title: "Untagged",
                                 systemImage: "tag",
-                                databaseView: DatabaseView(database: manager.database, tags: [tag]))
-                        .contextMenu(ContextMenu(menuItems: {
-                            Button("Rename") {
-                                self.sheet = .rename(tag: tag)
-                            }
-                            Button("Delete") {
-                                self.manager.pinboard.tags_delete(tag) { _ in
-                                    self.manager.updater.start()
-                                }
-                            }
-                            Divider()
-                            Button("Add to Favourites") {
-                                var favoriteTags = settings.favoriteTags
-                                favoriteTags.append(tag)
-                                settings.favoriteTags = favoriteTags
-                            }
-                            Divider()
-                            Button("Edit on Pinboard") {
-                                do {
-                                    guard let user = manager.user else {
-                                        return
-                                    }
-                                    NSWorkspace.shared.open(try tag.pinboardUrl(for: user))
-                                } catch {
-                                    print("Failed to open on Pinboard error \(error)")
-                                }
-                            }
-                        }))
+                                databaseView: DatabaseView(database: manager.database))
 
                 }
-            }
+                Section(header: Text("Favourites")) {
+                    ForEach(settings.favoriteTags.sorted(), id: \.favoriteId) { tag in
 
+                        SidebarLink(selection: $selection,
+                                    tag: tag.favoriteId,
+                                    title: tag,
+                                    systemImage: "tag",
+                                    databaseView: DatabaseView(database: manager.database, tags: [tag]))
+                            .contextMenu(ContextMenu(menuItems: {
+                                Button("Remove from Favourites") {
+                                    settings.favoriteTags = settings.favoriteTags.filter { $0 != tag }
+                                }
+                                Divider()
+                                Button("Edit on Pinboard") {
+                                    do {
+                                        guard let user = manager.user else {
+                                            return
+                                        }
+                                        NSWorkspace.shared.open(try tag.pinboardUrl(for: user))
+                                    } catch {
+                                        print("Failed to open on Pinboard error \(error)")
+                                    }
+                                }
+                            }))
+
+                    }
+                }
+                Section(header: Text("Tags")) {
+                    ForEach(tagsView.tags, id: \.tagId) { tag in
+
+                        SidebarLink(selection: $selection,
+                                    tag: tag.tagId,
+                                    title: tag,
+                                    systemImage: "tag",
+                                    databaseView: DatabaseView(database: manager.database, tags: [tag]))
+                            .contextMenu(ContextMenu(menuItems: {
+                                Button("Rename") {
+                                    self.sheet = .rename(tag: tag)
+                                }
+                                Button("Delete") {
+                                    self.manager.pinboard.tags_delete(tag) { _ in
+                                        self.manager.updater.start()
+                                    }
+                                }
+                                Divider()
+                                Button("Add to Favourites") {
+                                    var favoriteTags = settings.favoriteTags
+                                    favoriteTags.append(tag)
+                                    settings.favoriteTags = favoriteTags
+                                }
+                                Divider()
+                                Button("Edit on Pinboard") {
+                                    do {
+                                        guard let user = manager.user else {
+                                            return
+                                        }
+                                        NSWorkspace.shared.open(try tag.pinboardUrl(for: user))
+                                    } catch {
+                                        print("Failed to open on Pinboard error \(error)")
+                                    }
+                                }
+                            }))
+
+                    }
+                }
+
+            }
+            .onChange(of: selection) { selection in
+                guard let selection = selection else {
+                    return
+                }
+                print("scrolling to \(selection)")
+                scrollView.scrollTo(selection)
+            }
         }
         .sheet(item: $sheet) { sheet in
             switch sheet {

--- a/macos/Bookmarks/Views/Sidebar.swift
+++ b/macos/Bookmarks/Views/Sidebar.swift
@@ -63,7 +63,7 @@ struct Sidebar: View {
                                 tag: .untagged,
                                 title: "Untagged",
                                 systemImage: "tag",
-                                databaseView: DatabaseView(database: manager.database))
+                                databaseView: DatabaseView(database: manager.database, tags: []))
 
                 }
                 Section(header: Text("Favourites")) {
@@ -106,6 +106,7 @@ struct Sidebar: View {
                                     self.sheet = .rename(tag: tag)
                                 }
                                 Button("Delete") {
+                                    self.manager.database.delete(tag: tag, completion: { _ in })
                                     self.manager.pinboard.tags_delete(tag) { _ in
                                         self.manager.updater.start()
                                     }

--- a/macos/Bookmarks/Views/Sidebar.swift
+++ b/macos/Bookmarks/Views/Sidebar.swift
@@ -24,66 +24,22 @@ import SwiftUI
 import BookmarksCore
 import Interact
 
-enum Tags {
-    case allBookmarks
-    case untagged
-    case favorites(tag: String)
-    case tag(tag: String)
-}
-
-
-struct FocusedMessageKey : FocusedValueKey {
-        typealias Value = Binding<Tags?>
-}
-
-
-extension FocusedValues {
-    var sidebarSelection: FocusedMessageKey.Value? {
-        get { self[FocusedMessageKey.self] }
-        set { self[FocusedMessageKey.self] = newValue }
-    }
-}
-
-// TODO: Rename this.
-extension Tags: CustomStringConvertible, Hashable, Identifiable {
-
-    var id: String { String(describing: self) }
-
-    var description: String {
-        switch self {
-        case .allBookmarks:
-            return "uk.co.inseven.bookmarks.all-bookmarks"
-        case .untagged:
-            return "uk.co.inseven.bookmarks.untagged"
-        case .favorites(let tag):
-            return "uk.co.inseven.bookmarks.favorites.\(tag)"
-        case .tag(let tag):
-            return "uk.co.inseven.bookmarks.tag.\(tag)"
-        }
-    }
-
-}
-
-
 extension String {
 
-    var favoriteId: Tags { Tags.favorites(tag: self) }
-    var tagId: Tags { Tags.tag(tag: self) }
+    var favoriteId: BookmarksSection { .favorite(tag: self) }
+    var tagId: BookmarksSection { .tag(tag: self) }
 
 }
-
-// TODO: Wrap the navigation link in something more elegant?
-
 
 struct SidebarLink: View {
 
-    var selection: Binding<Tags?>
-    var tag: Tags
+    var selection: Binding<BookmarksSection?>
+    var tag: BookmarksSection
     var title: String
     var systemImage: String
     var databaseView: DatabaseView
 
-    func selectionActiveBinding(_ tag: Tags) -> Binding<Bool> {
+    func selectionActiveBinding(_ tag: BookmarksSection) -> Binding<Bool> {
         return Binding {
             selection.wrappedValue == tag
         } set: { value in
@@ -117,10 +73,10 @@ struct Sidebar: View {
     @StateObject var tagsView: TagsView
     @ObservedObject var settings: BookmarksCore.Settings
 
-    @State var selection: Tags? = .allBookmarks
+    @State var selection: BookmarksSection? = .all
     @State var sheet: SheetType? = nil
 
-    func selectionActiveBinding(_ tag: Tags) -> Binding<Bool> {
+    func selectionActiveBinding(_ tag: BookmarksSection) -> Binding<Bool> {
         return Binding {
             self.selection == tag
         } set: { value in
@@ -136,7 +92,7 @@ struct Sidebar: View {
             Section {
 
                 SidebarLink(selection: $selection,
-                            tag: .allBookmarks,
+                            tag: .all,
                             title: "All Bookmarks",
                             systemImage: "bookmark",
                             databaseView: DatabaseView(database: manager.database))
@@ -227,12 +183,6 @@ struct Sidebar: View {
         .onDisappear {
             tagsView.stop()
         }
-        .onChange(of: selection, perform: { selection in
-            guard let selection = selection else {
-                return
-            }
-            print("selection = \(selection)")
-        })
     }
 }
 

--- a/macos/Bookmarks/Views/SidebarLink.swift
+++ b/macos/Bookmarks/Views/SidebarLink.swift
@@ -20,46 +20,35 @@
 
 import SwiftUI
 
-enum BookmarksSection {
-    case all
-    case untagged
-    case favorite(tag: String)
-    case tag(tag: String)
-}
+import BookmarksCore
 
-extension BookmarksSection: CustomStringConvertible, Hashable, Identifiable {
+struct SidebarLink: View {
 
-    var id: String { String(describing: self) }
+    var selection: Binding<BookmarksSection?>
+    var tag: BookmarksSection
+    var title: String
+    var systemImage: String
+    var databaseView: DatabaseView
 
-    var description: String {
-        switch self {
-        case .all:
-            return "uk.co.inseven.bookmarks.all-bookmarks"
-        case .untagged:
-            return "uk.co.inseven.bookmarks.untagged"
-        case .favorite(let tag):
-            return "uk.co.inseven.bookmarks.favorites.\(tag)"
-        case .tag(let tag):
-            return "uk.co.inseven.bookmarks.tags.\(tag)"
+    func selectionActiveBinding(_ tag: BookmarksSection) -> Binding<Bool> {
+        return Binding {
+            selection.wrappedValue == tag
+        } set: { value in
+            guard value == true else {
+                return
+            }
+            selection.wrappedValue = tag
         }
     }
 
-}
-
-extension String {
-
-    var favoriteId: BookmarksSection { .favorite(tag: self) }
-    var tagId: BookmarksSection { .tag(tag: self) }
-
-}
-
-struct FocusedMessageKey : FocusedValueKey {
-        typealias Value = Binding<BookmarksSection?>
-}
-
-extension FocusedValues {
-    var sidebarSelection: FocusedMessageKey.Value? {
-        get { self[FocusedMessageKey.self] }
-        set { self[FocusedMessageKey.self] = newValue }
+    var body: some View {
+        NavigationLink(destination: ContentView(sidebarSelection: selection, databaseView: databaseView)
+                        .navigationTitle(title),
+                       isActive: selectionActiveBinding(tag)) {
+            Label(title, systemImage: systemImage)
+        }
+        .tag(tag)  // We set a tag so the list view knows what's selected...
+        .id(tag)   // ... and an id so we can scroll to the items 🤦🏻‍♂️
     }
+
 }


### PR DESCRIPTION
This change addresses some bugs that prevented sidebar selection tracking from working, shares this state with the content views, and uses this within the content view to select sidebar items (tabs) from the bookmark context menu. It also introduces some quick-fixes to improve the performance of item and tag deletion (pre-deleting in the database), improves the database tests, and adds very cursory by-tag filtering from the search field.