### PR TITLE
feat: Refresh bookmarks from the file menu

### DIFF
--- a/core/BookmarksCore/Common/BookmarksManager.swift
+++ b/core/BookmarksCore/Common/BookmarksManager.swift
@@ -38,7 +38,7 @@ public class BookmarksManager {
     public var thumbnailManager: ThumbnailManager
     var downloadManager: DownloadManager
     public var settings = Settings()
-    public var updater: Updater
+    fileprivate var updater: Updater
     public var pinboard: Pinboard
 
     public var cache: NSCache = NSCache<NSString, Image>()
@@ -68,6 +68,10 @@ public class BookmarksManager {
 
     public var user: String? {
         settings.pinboardApiKey.components(separatedBy: ":").first
+    }
+
+    public func refresh() {
+        self.updater.update()
     }
 
     @objc

--- a/core/BookmarksCore/Pinboard/Pinboard.swift
+++ b/core/BookmarksCore/Pinboard/Pinboard.swift
@@ -124,7 +124,6 @@ public class Pinboard {
         }
     }
 
-
     public func tags_rename(_ old: String, to new: String, completion: @escaping (Result<Bool, Swift.Error>) -> Void) {
         let parameters = [
             "old": old,

--- a/ios/Bookmarks/BookmarksApp.swift
+++ b/ios/Bookmarks/BookmarksApp.swift
@@ -35,7 +35,7 @@ struct BookmarksApp: App {
         .onChange(of: phase) { phase in
             switch phase {
             case .active:
-                manager.updater.update()
+                manager.refresh()
             case .background:
                 break
             case .inactive:

--- a/macos/Bookmarks/BookmarksApp.swift
+++ b/macos/Bookmarks/BookmarksApp.swift
@@ -38,6 +38,13 @@ struct BookmarksApp: App {
         }
         .commands {
             SidebarCommands()
+            CommandGroup(after: .newItem) {
+                Divider()
+                Button("Refresh") {
+                    manager.refresh()
+                }
+                .keyboardShortcut("r", modifiers: .command)
+            }
         }
         SwiftUI.Settings {
             SettingsView()

--- a/macos/Bookmarks/Views/ContentView.swift
+++ b/macos/Bookmarks/Views/ContentView.swift
@@ -78,7 +78,7 @@ struct ContentView: View {
                                     manager.pinboard.posts_delete(url: item.url) { result in
                                         switch result {
                                         case .success:
-                                            manager.updater.update()
+                                            manager.refresh()
                                         case .failure(let error):
                                             print("Failed to delete bookmark with error \(error)")
                                         }
@@ -124,7 +124,7 @@ struct ContentView: View {
         .toolbar {
             ToolbarItem {
                 Button {
-                    manager.updater.update()
+                    manager.refresh()
                 } label: {
                     SwiftUI.Image(systemName: "arrow.clockwise")
                 }

--- a/macos/Bookmarks/Views/RenameTagView.swift
+++ b/macos/Bookmarks/Views/RenameTagView.swift
@@ -57,7 +57,7 @@ struct RenameTagView: View {
                                 isBusy = false
                             case .success:
                                 print("Successfully renamed tag")
-                                manager.updater.update()
+                                manager.refresh()
                                 presentationMode.wrappedValue.dismiss()
                             }
                         }

--- a/macos/Bookmarks/Views/Sidebar.swift
+++ b/macos/Bookmarks/Views/Sidebar.swift
@@ -108,7 +108,7 @@ struct Sidebar: View {
                                 Button("Delete") {
                                     self.manager.database.delete(tag: tag, completion: { _ in })
                                     self.manager.pinboard.tags_delete(tag) { _ in
-                                        self.manager.updater.update()
+                                        self.manager.refresh()
                                     }
                                 }
                                 Divider()


### PR DESCRIPTION
This includes a drive-by fix to make the `Updater` instance private, and force refresh operations to go through the manager (with a view to making the whole thing more self contained and easier to hold).