### PR TITLE
ci: Don't notify TestFlight users of new builds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -54,6 +54,7 @@ lane :upload do |options|
     upload_to_testflight(
         api_key: api_key,
         skip_submission: true,
-        ipa: options[:ipa]
+        ipa: options[:ipa],
+        notify_external_testers: false
     )
 end


### PR DESCRIPTION
Since we're uploading new releases on every main build, it might be a bit much to notify on every release. Since TestFlight now supports automatic updates, it shouldn't be necessary.