### PR TITLE
feat: Show the app version in the iOS app

### DIFF
--- a/ios/Bookmarks-iOS.xcodeproj/project.pbxproj
+++ b/ios/Bookmarks-iOS.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		D81E7484254A0D1B002336DC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81E7483254A0D1B002336DC /* ContentView.swift */; };
+		D81FBAC426B99E26004AC4A4 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81FBAC326B99E26004AC4A4 /* AboutView.swift */; };
+		D81FBAC626B99E70004AC4A4 /* LicenseRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81FBAC526B99E70004AC4A4 /* LicenseRow.swift */; };
+		D81FBAC826B99E94004AC4A4 /* LicenseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81FBAC726B99E94004AC4A4 /* LicenseView.swift */; };
 		D832EEC724816901004C64E3 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D832EEC624816901004C64E3 /* SettingsView.swift */; };
 		D8478554261539AA00B2318B /* BookmarksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8478553261539AA00B2318B /* BookmarksView.swift */; };
 		D84785822615474900B2318B /* SearchBoxModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84785812615474900B2318B /* SearchBoxModifier.swift */; };
@@ -58,6 +61,9 @@
 
 /* Begin PBXFileReference section */
 		D81E7483254A0D1B002336DC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		D81FBAC326B99E26004AC4A4 /* AboutView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
+		D81FBAC526B99E70004AC4A4 /* LicenseRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LicenseRow.swift; sourceTree = "<group>"; };
+		D81FBAC726B99E94004AC4A4 /* LicenseView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LicenseView.swift; sourceTree = "<group>"; };
 		D832EEC624816901004C64E3 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		D832EECA2481B6D1004C64E3 /* Bookmarks.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Bookmarks.entitlements; sourceTree = "<group>"; };
 		D8478553261539AA00B2318B /* BookmarksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksView.swift; sourceTree = "<group>"; };
@@ -112,8 +118,11 @@
 		D8578479254FF56E00AE241C /* Interface */ = {
 			isa = PBXGroup;
 			children = (
+				D81FBAC326B99E26004AC4A4 /* AboutView.swift */,
 				D8478553261539AA00B2318B /* BookmarksView.swift */,
 				D81E7483254A0D1B002336DC /* ContentView.swift */,
+				D81FBAC526B99E70004AC4A4 /* LicenseRow.swift */,
+				D81FBAC726B99E94004AC4A4 /* LicenseView.swift */,
 				D84785812615474900B2318B /* SearchBoxModifier.swift */,
 				D832EEC624816901004C64E3 /* SettingsView.swift */,
 			);
@@ -329,9 +338,12 @@
 			files = (
 				D832EEC724816901004C64E3 /* SettingsView.swift in Sources */,
 				D81E7484254A0D1B002336DC /* ContentView.swift in Sources */,
+				D81FBAC826B99E94004AC4A4 /* LicenseView.swift in Sources */,
 				D8BDE1182551C56100C95945 /* BookmarksApp.swift in Sources */,
 				D84785822615474900B2318B /* SearchBoxModifier.swift in Sources */,
+				D81FBAC426B99E26004AC4A4 /* AboutView.swift in Sources */,
 				D8478554261539AA00B2318B /* BookmarksView.swift in Sources */,
+				D81FBAC626B99E70004AC4A4 /* LicenseRow.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Bookmarks/Interface/AboutView.swift
+++ b/ios/Bookmarks/Interface/AboutView.swift
@@ -1,0 +1,103 @@
+// Copyright (c) 2020-2021 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftUI
+
+extension Text {
+
+    init(contentsOf filename: String) {
+        guard let path = Bundle.main.path(forResource: filename, ofType: nil),
+              let contents = try? String(contentsOfFile: path) else {
+            self.init("missing file")
+            return
+        }
+        self.init(contents)
+    }
+
+}
+
+struct AboutView: View {
+
+    @Environment(\.presentationMode) var presentationMode
+
+    var version: String? {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    }
+
+    var build: String? {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+    }
+
+    var people = [
+        "Blake Merryman",
+        "Joanne Wong",
+        "Lukas Fittl",
+        "Pavlos Vinieratos",
+        "Sara Frederixon",
+        "Sarah Barbour",
+        "Terrence Talbot",
+    ]
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("App")) {
+                    HStack {
+                        Text("Version")
+                        Spacer()
+                        Text(version ?? "")
+                            .foregroundColor(.secondary)
+                    }
+                    HStack {
+                        Text("Build")
+                        Spacer()
+                        Text(build ?? "")
+                            .foregroundColor(.secondary)
+                    }
+                }
+                Section(header: Text("InSeven Limited")) {
+                    Button("Company") {
+                        UIApplication.shared.open(URL(string: "https://inseven.co.uk")!)
+                    }
+                    Button("Support") {
+                        var components = URLComponents()
+                        components.scheme = "mailto"
+                        components.path = "support@inseven.co.uk"
+                        components.queryItems = [URLQueryItem(name: "subject", value: "Bookmarks Support")]
+                        UIApplication.shared.open(components.url!)
+                    }
+                }
+                Section(header: Text("With Thanks")) {
+                    ForEach(people) { person in
+                        Text(person)
+                    }
+                }
+            }
+            .navigationBarTitle("About", displayMode: .inline)
+            .navigationBarItems(trailing: Button(action: {
+                presentationMode.wrappedValue.dismiss()
+            }) {
+                Text("Done")
+                    .fontWeight(.regular)
+            })
+        }
+    }
+
+}

--- a/ios/Bookmarks/Interface/LicenseRow.swift
+++ b/ios/Bookmarks/Interface/LicenseRow.swift
@@ -1,0 +1,42 @@
+// Copyright (c) 2020-2021 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftUI
+
+struct LicenseRow: View {
+
+    var name: String
+    var author: String
+    var filename: String
+
+    @State var isShowingDetails = false
+
+    var body: some View {
+        NavigationLink(destination: LicenseView(name: name, filename: filename), isActive: $isShowingDetails) {
+            HStack {
+                Text(name)
+                Spacer()
+                Text(author)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+}

--- a/ios/Bookmarks/Interface/LicenseView.swift
+++ b/ios/Bookmarks/Interface/LicenseView.swift
@@ -1,0 +1,24 @@
+//
+//  LicenseView.swift
+//  Anytime
+//
+//  Created by Jason Barrie Morley on 03/10/2020.
+//  Copyright © 2020 InSeven Limited. All rights reserved.
+//
+
+import SwiftUI
+
+struct LicenseView: View {
+
+    var name: String
+    var filename: String
+
+    var body: some View {
+        ScrollView {
+            Text(contentsOf: filename)
+                .padding()
+        }
+        .navigationTitle(name)
+    }
+
+}

--- a/ios/Bookmarks/Interface/LicenseView.swift
+++ b/ios/Bookmarks/Interface/LicenseView.swift
@@ -1,10 +1,22 @@
+// Copyright (c) 2020-2021 InSeven Limited
 //
-//  LicenseView.swift
-//  Anytime
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 03/10/2020.
-//  Copyright © 2020 InSeven Limited. All rights reserved.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/ios/Bookmarks/Interface/SettingsView.swift
+++ b/ios/Bookmarks/Interface/SettingsView.swift
@@ -24,6 +24,10 @@ import BookmarksCore
 
 struct SettingsView: View {
 
+    enum SheetType {
+        case about
+    }
+
     enum AlertType {
         case error(error: Error)
         case success(message: String)
@@ -33,6 +37,7 @@ struct SettingsView: View {
     @Environment(\.presentationMode) var presentationMode
 
     @ObservedObject var settings: Settings
+    @State var sheet: SheetType?
     @State var alert: AlertType?
 
     var body: some View {
@@ -74,6 +79,11 @@ struct SettingsView: View {
                         Text("Clear Cache").foregroundColor(.red)
                     }
                 }
+                Section {
+                    Button(action: { sheet = .about }) {
+                        Text("About Bookmarks")
+                    }
+                }
             }
         }
         .navigationBarTitle("Settings", displayMode: .inline)
@@ -83,6 +93,12 @@ struct SettingsView: View {
             Text("Done")
                 .fontWeight(.regular)
         })
+        .sheet(item: $sheet) { sheet in
+            switch sheet {
+            case .about:
+                AboutView()
+            }
+        }
         .alert(item: $alert) { alert in
             switch alert {
             case .error(let error):
@@ -90,6 +106,15 @@ struct SettingsView: View {
             case .success(let message):
                 return Alert(title: Text("Success"), message: Text(message))
             }
+        }
+    }
+}
+
+extension SettingsView.SheetType: Identifiable {
+    public var id: String {
+        switch self {
+        case .about:
+            return "about"
         }
     }
 }


### PR DESCRIPTION
This change also introduces the `LicenseRow` and `LicenseView` SwiftUI structs in anticipation of listing the third-party licenses in the app.