### PR TITLE
fix: Don't show the Favorites section if there are no favorite tags

### DIFF
--- a/macos/Bookmarks/Views/Sidebar.swift
+++ b/macos/Bookmarks/Views/Sidebar.swift
@@ -122,12 +122,12 @@ struct Sidebar: View {
 
                 if settings.favoriteTags.count > 0 {
 
-                    Section(header: Text("Favourites")) {
+                    Section(header: Text("Favorites")) {
                         ForEach(settings.favoriteTags.sorted(), id: \.section) { tag in
-                            
+
                             SidebarLink(tag: tag.section)
                                 .contextMenu(ContextMenu(menuItems: {
-                                    Button("Remove from Favourites") {
+                                    Button("Remove from Favorites") {
                                         settings.favoriteTags = settings.favoriteTags.filter { $0 != tag }
                                     }
                                     Divider()
@@ -142,7 +142,7 @@ struct Sidebar: View {
                                         }
                                     }
                                 }))
-                            
+
                         }
                     }
 
@@ -160,7 +160,7 @@ struct Sidebar: View {
                                     self.manager.deleteTag(tag: tag) { _ in }
                                 }
                                 Divider()
-                                Button("Add to Favourites") {
+                                Button("Add to Favorites") {
                                     var favoriteTags = settings.favoriteTags
                                     favoriteTags.append(tag)
                                     settings.favoriteTags = favoriteTags

--- a/macos/Bookmarks/Views/Sidebar.swift
+++ b/macos/Bookmarks/Views/Sidebar.swift
@@ -113,36 +113,29 @@ struct Sidebar: View {
 
                 Section(header: Text("Smart Filters")) {
 
-                    SidebarLink(selection: $selection,
-                                tag: .all,
+                    SidebarLink(tag: .all,
                                 query: True().eraseToAnyQuery())
 
-                    SidebarLink(selection: $selection,
-                                tag: .shared(false),
+                    SidebarLink(tag: .shared(false),
                                 query: Shared(false).eraseToAnyQuery())
 
-                    SidebarLink(selection: $selection,
-                                tag: .shared(true),
+                    SidebarLink(tag: .shared(true),
                                 query: Shared(true).eraseToAnyQuery())
 
-                    SidebarLink(selection: $selection,
-                                tag: .today,
+                    SidebarLink(tag: .today,
                                 query: Today().eraseToAnyQuery())
 
-                    SidebarLink(selection: $selection,
-                                tag: .unread,
+                    SidebarLink(tag: .unread,
                                 query: Unread().eraseToAnyQuery())
 
-                    SidebarLink(selection: $selection,
-                                tag: .untagged,
+                    SidebarLink(tag: .untagged,
                                 query: Untagged().eraseToAnyQuery())
 
                 }
                 Section(header: Text("Favourites")) {
                     ForEach(settings.favoriteTags.sorted(), id: \.section) { tag in
 
-                        SidebarLink(selection: $selection,
-                                    tag: tag.section,
+                        SidebarLink(tag: tag.section,
                                     query: Tag(tag).eraseToAnyQuery())
                             .contextMenu(ContextMenu(menuItems: {
                                 Button("Remove from Favourites") {
@@ -166,8 +159,7 @@ struct Sidebar: View {
                 Section(header: Text("Tags")) {
                     ForEach(tags, id: \.section) { tag in
 
-                        SidebarLink(selection: $selection,
-                                    tag: tag.section,
+                        SidebarLink(tag: tag.section,
                                     query: Tag(tag).eraseToAnyQuery())
                             .contextMenu(ContextMenu(menuItems: {
                                 Button("Rename") {

--- a/macos/Bookmarks/Views/Sidebar.swift
+++ b/macos/Bookmarks/Views/Sidebar.swift
@@ -112,55 +112,46 @@ struct Sidebar: View {
             List(selection: $selection) {
 
                 Section(header: Text("Smart Filters")) {
-
-                    SidebarLink(tag: .all,
-                                query: True().eraseToAnyQuery())
-
-                    SidebarLink(tag: .shared(false),
-                                query: Shared(false).eraseToAnyQuery())
-
-                    SidebarLink(tag: .shared(true),
-                                query: Shared(true).eraseToAnyQuery())
-
-                    SidebarLink(tag: .today,
-                                query: Today().eraseToAnyQuery())
-
-                    SidebarLink(tag: .unread,
-                                query: Unread().eraseToAnyQuery())
-
-                    SidebarLink(tag: .untagged,
-                                query: Untagged().eraseToAnyQuery())
-
+                    SidebarLink(tag: .all)
+                    SidebarLink(tag: .shared(false))
+                    SidebarLink(tag: .shared(true))
+                    SidebarLink(tag: .today)
+                    SidebarLink(tag: .unread)
+                    SidebarLink(tag: .untagged)
                 }
-                Section(header: Text("Favourites")) {
-                    ForEach(settings.favoriteTags.sorted(), id: \.section) { tag in
 
-                        SidebarLink(tag: tag.section,
-                                    query: Tag(tag).eraseToAnyQuery())
-                            .contextMenu(ContextMenu(menuItems: {
-                                Button("Remove from Favourites") {
-                                    settings.favoriteTags = settings.favoriteTags.filter { $0 != tag }
-                                }
-                                Divider()
-                                Button("Edit on Pinboard") {
-                                    do {
-                                        guard let user = manager.user else {
-                                            return
-                                        }
-                                        NSWorkspace.shared.open(try tag.pinboardTagUrl(for: user))
-                                    } catch {
-                                        print("Failed to open on Pinboard error \(error)")
+                if settings.favoriteTags.count > 0 {
+
+                    Section(header: Text("Favourites")) {
+                        ForEach(settings.favoriteTags.sorted(), id: \.section) { tag in
+                            
+                            SidebarLink(tag: tag.section)
+                                .contextMenu(ContextMenu(menuItems: {
+                                    Button("Remove from Favourites") {
+                                        settings.favoriteTags = settings.favoriteTags.filter { $0 != tag }
                                     }
-                                }
-                            }))
-
+                                    Divider()
+                                    Button("Edit on Pinboard") {
+                                        do {
+                                            guard let user = manager.user else {
+                                                return
+                                            }
+                                            NSWorkspace.shared.open(try tag.pinboardTagUrl(for: user))
+                                        } catch {
+                                            print("Failed to open on Pinboard error \(error)")
+                                        }
+                                    }
+                                }))
+                            
+                        }
                     }
+
                 }
+
                 Section(header: Text("Tags")) {
                     ForEach(tags, id: \.section) { tag in
 
-                        SidebarLink(tag: tag.section,
-                                    query: Tag(tag).eraseToAnyQuery())
+                        SidebarLink(tag: tag.section)
                             .contextMenu(ContextMenu(menuItems: {
                                 Button("Rename") {
                                     self.sheet = .rename(tag: tag)

--- a/macos/Bookmarks/Views/SidebarLink.swift
+++ b/macos/Bookmarks/Views/SidebarLink.swift
@@ -26,7 +26,6 @@ struct SidebarLink: View {
 
     @Environment(\.manager) var manager: BookmarksManager
 
-//    var selection: Binding<BookmarksSection?>
     var tag: BookmarksSection
     var query: AnyQuery
 

--- a/macos/Bookmarks/Views/SidebarLink.swift
+++ b/macos/Bookmarks/Views/SidebarLink.swift
@@ -27,7 +27,6 @@ struct SidebarLink: View {
     @Environment(\.manager) var manager: BookmarksManager
 
     var tag: BookmarksSection
-    var query: AnyQuery
 
     var body: some View {
         HStack {

--- a/macos/Bookmarks/Views/SidebarLink.swift
+++ b/macos/Bookmarks/Views/SidebarLink.swift
@@ -26,20 +26,9 @@ struct SidebarLink: View {
 
     @Environment(\.manager) var manager: BookmarksManager
 
-    var selection: Binding<BookmarksSection?>
+//    var selection: Binding<BookmarksSection?>
     var tag: BookmarksSection
     var query: AnyQuery
-
-    func selectionActiveBinding(_ tag: BookmarksSection) -> Binding<Bool> {
-        return Binding {
-            selection.wrappedValue == tag
-        } set: { value in
-            guard value == true else {
-                return
-            }
-            selection.wrappedValue = tag
-        }
-    }
 
     var body: some View {
         HStack {


### PR DESCRIPTION
This includes a drive-by fix that removes code from `SidebarLink` left-over from the previous `NavigationLink` based approach.