### PR TITLE
fix: Renamed tags did not update until an app relaunch

### DIFF
--- a/core/BookmarksCore/Common/BookmarksManager.swift
+++ b/core/BookmarksCore/Common/BookmarksManager.swift
@@ -70,8 +70,8 @@ public class BookmarksManager {
         settings.pinboardApiKey.components(separatedBy: ":").first
     }
 
-    public func refresh() {
-        self.updater.update()
+    public func refresh(force: Bool = false) {
+        self.updater.update(force: force)
     }
 
     // TODO: Move the Bookmark update APIs into the updater #237
@@ -107,7 +107,7 @@ public class BookmarksManager {
         DispatchQueue.global(qos: .userInitiated).async {
             let result = Result {
                 try self.pinboard.tagsRename(old, to: new)
-                self.refresh()
+                self.refresh(force: true)
             }
             completion(result)
         }

--- a/core/BookmarksCore/Common/Updater.swift
+++ b/core/BookmarksCore/Common/Updater.swift
@@ -38,7 +38,7 @@ public class Updater {
         self.pinboard = pinboard
     }
 
-    fileprivate func syncQueue_update() {
+    fileprivate func syncQueue_update(force: Bool) {
         dispatchPrecondition(condition: .onQueue(syncQueue))
 
         print("updating...")
@@ -48,7 +48,8 @@ public class Updater {
             // Check to see when the bookmarks were last updated and don't update if there are no new changes.
             let update = try self.pinboard.postsUpdate()
             if let lastUpdate = self.lastUpdate,
-               lastUpdate >= update.updateTime {
+               lastUpdate >= update.updateTime,
+               !force {
                 print("skipping empty update")
                 return
             }
@@ -103,15 +104,15 @@ public class Updater {
                     return
                 }
                 self.syncQueue.async {
-                    self.syncQueue_update()
+                    self.syncQueue_update(force: true)
                 }
             }
         }
     }
 
-    public func update() {
+    public func update(force: Bool = false) {
         syncQueue.async {
-            self.syncQueue_update()
+            self.syncQueue_update(force: force)
         }
     }
 


### PR DESCRIPTION
Unfortunately the Pinboard `posts/update` endpoint doesn't report any updates following a tag rename as the posts themselves haven't actually been updated 🤦🏻‍♂️. This change works around that behaviour for the time being by simple forcing a full update following a rename. A better longer-term solution might be to simply not require a fetch from Pinboard in the case of a successful client-side and server-side update (we can probably safely assume that the two stores are in sync at this point).