### PR TITLE
feat: Go back and forward in your search and view history

### DIFF
--- a/macos/Bookmarks/BookmarksApp.swift
+++ b/macos/Bookmarks/BookmarksApp.swift
@@ -33,7 +33,33 @@ struct BookmarksApp: App {
         WindowGroup {
             NavigationView {
                 Sidebar(tagsView: TagsView(database: manager.database), settings: manager.settings, selection: $selection)
+                    .toolbar {
+                        ToolbarItem(placement: .destructiveAction) {
+                            Button {
+                                manager.refresh()
+                            } label: {
+                                SwiftUI.Image(systemName: "arrow.clockwise")
+                            }
+                        }
+                    }
+
                 ContentView(sidebarSelection: $selection, database: manager.database)
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigation) {
+                    HStack {
+                        Button {
+                            manager.refresh()
+                        } label: {
+                            SwiftUI.Image(systemName: "chevron.backward")
+                        }
+                        Button {
+                            manager.refresh()
+                        } label: {
+                            SwiftUI.Image(systemName: "chevron.forward")
+                        }
+                    }
+                }
             }
             .frameAutosaveName("Main Window")
         }

--- a/macos/Bookmarks/Views/ContentView.swift
+++ b/macos/Bookmarks/Views/ContentView.swift
@@ -116,13 +116,6 @@ struct ContentView: View {
         }
         .toolbar {
             ToolbarItem {
-                Button {
-                    manager.refresh()
-                } label: {
-                    SwiftUI.Image(systemName: "arrow.clockwise")
-                }
-            }
-            ToolbarItem {
                 SearchField(search: $searchDebouncer.value)
                     .frame(minWidth: 100, idealWidth: 300, maxWidth: .infinity)
             }


### PR DESCRIPTION
This is a very early branch / PR with some of the initial work to allow navigating through the search / view history. Since the macOS app relies exclusively on the search state to drive the app it works by simply storing a list of these searches and pushing / popping them.