### PR TITLE
refactor: Consolidate the bookmark URL accessors

### DIFF
--- a/core/BookmarksCore/Common/BookmarksManager.swift
+++ b/core/BookmarksCore/Common/BookmarksManager.swift
@@ -106,40 +106,18 @@ public class BookmarksManager {
         self.updater.deleteTag(tag, completion: completion)
     }
 
-    public func open(items: [Item], completion: @escaping (Result<Void, Error>) -> Void) {
-        let completion = DispatchQueue.main.asyncClosure(completion)
-        let many = open(urls: items.map { $0.url })
-        _ = many.sink { result in
-            switch result {
-            case .finished:
-                completion(.success(()))
-            case .failure(let error):
-                completion(.failure(error))
-            }
-        } receiveValue: { _ in }
+    public func openItems(_ items: Set<Item>,
+                          location: Item.Location = .web,
+                          completion: @escaping (Result<Void, Error>) -> Void) {
+        openItems(Array(items), location: location, completion: completion)
     }
 
-    public func openOnInternetArchive(items: [Item], completion: @escaping (Result<Void, Error>) -> Void) {
+    public func openItems(_ items: [Item],
+                          location: Item.Location = .web,
+                          completion: @escaping (Result<Void, Error>) -> Void) {
         let completion = DispatchQueue.main.asyncClosure(completion)
         do {
-            let many = open(urls: try items.map { try $0.internetArchiveUrl() })
-            _ = many.sink { result in
-                switch result {
-                case .finished:
-                    completion(.success(()))
-                case .failure(let error):
-                    completion(.failure(error))
-                }
-            } receiveValue: { _ in }
-        } catch {
-            completion(.failure(error))
-        }
-    }
-
-    public func editOnPinboard(items: [Item], completion: @escaping (Result<Void, Error>) -> Void) {
-        let completion = DispatchQueue.main.asyncClosure(completion)
-        do {
-            let many = open(urls: try items.map { try $0.pinboardUrl() })
+            let many = open(urls: try items.map { try $0.url(location) })
             _ = many.sink { result in
                 switch result {
                 case .finished:

--- a/core/BookmarksCore/Store/Item.swift
+++ b/core/BookmarksCore/Store/Item.swift
@@ -26,6 +26,12 @@ import UIKit
 
 public class Item: Equatable {
 
+    public enum Location {
+        case web
+        case internetArchive
+        case pinboard
+    }
+
     public let identifier: String
     public let title: String
     public let url: URL
@@ -150,6 +156,19 @@ public class Item: Equatable {
              notes: notes)
     }
 
+    public func url(_ location: Location) throws -> URL {
+        switch location {
+        case .web:
+            return url
+        case .internetArchive:
+            return try "https://web.archive.org/web/*/".asUrl().appendingPathComponent(url.absoluteString)
+        case .pinboard:
+            return try "https://pinboard.in/add".asUrl().settingQueryItems([
+                URLQueryItem(name: "url", value: url.absoluteString)
+            ])
+        }
+    }
+
 }
 
 extension Item: Identifiable {
@@ -170,24 +189,6 @@ extension Item: CustomStringConvertible {
 
     public var description: String {
         "\(url.absoluteString) (title: \(title), tags: [\(tags.joined(separator: ", "))], date: \(date), toRead: \(toRead), notes: '\(self.notes)')"
-    }
-
-}
-
-extension Item {
-
-    // TODO: Update to throwing properties when adopting Swift 5.5 #142
-     //       https://github.com/inseven/bookmarks/issues/142
-    public func internetArchiveUrl() throws -> URL {
-        try "https://web.archive.org/web/*/".asUrl().appendingPathComponent(url.absoluteString)
-    }
-
-    // TODO: Update to throwing properties when adopting Swift 5.5 #142
-     //       https://github.com/inseven/bookmarks/issues/142
-    public func pinboardUrl() throws -> URL {
-         try "https://pinboard.in/add".asUrl().settingQueryItems([
-            URLQueryItem(name: "url", value: url.absoluteString)
-        ])
     }
 
 }

--- a/core/BookmarksCore/Store/Item.swift
+++ b/core/BookmarksCore/Store/Item.swift
@@ -20,10 +20,6 @@
 
 import Foundation
 
-#if os(iOS)
-import UIKit
-#endif
-
 public class Item: Equatable {
 
     public enum Location {

--- a/macos/Bookmarks/Commands/BookmarkEditCommands.swift
+++ b/macos/Bookmarks/Commands/BookmarkEditCommands.swift
@@ -40,8 +40,9 @@ struct BookmarkEditCommands: View {
             let items = selection.map { $0.setting(shared: !shared) }
             manager.updateItems(items, completion: errorHandlingCompletion(errorHandler))
         }
+        Divider()
         Button("Edit on Pinboard") {
-            manager.editOnPinboard(items: Array(selection), completion: errorHandlingCompletion(errorHandler))
+            manager.openItems(selection, location: .pinboard, completion: errorHandlingCompletion(errorHandler))
         }
     }
 }

--- a/macos/Bookmarks/Commands/BookmarkOpenCommands.swift
+++ b/macos/Bookmarks/Commands/BookmarkOpenCommands.swift
@@ -31,10 +31,10 @@ struct BookmarkOpenCommands: View {
 
     var body: some View {
         Button("Open") {
-            manager.open(items: Array(selection), completion: errorHandlingCompletion(errorHandler))
+            manager.openItems(selection, completion: errorHandlingCompletion(errorHandler))
         }
         Button("Open on Internet Archive") {
-            manager.openOnInternetArchive(items: Array(selection), completion: errorHandlingCompletion(errorHandler))
+            manager.openItems(selection, location: .internetArchive, completion: errorHandlingCompletion(errorHandler))
         }
     }
 }


### PR DESCRIPTION
This change introduces a new enum, `Item.Location` describing the location of the desired URL (Internet Archive, Pinboard, etc), and a unified function for getting the URL that uses this. It also introduces a drive-by fix to clean up the context menu by adding an additional divider.