### PR TITLE
ci: Remove xcpretty from the build scripts

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -100,7 +100,7 @@ function build_scheme {
         -scheme "$1" \
         CODE_SIGN_IDENTITY="" \
         CODE_SIGNING_REQUIRED=NO \
-        CODE_SIGNING_ALLOWED=NO "${@:2}" | xcpretty
+        CODE_SIGNING_ALLOWED=NO "${@:2}"
 }
 
 cd "$ROOT_DIRECTORY"
@@ -166,7 +166,7 @@ xcode_project \
     OTHER_CODE_SIGN_FLAGS="--keychain=\"${KEYCHAIN_PATH}\"" \
     BUILD_NUMBER=$BUILD_NUMBER \
     MARKETING_VERSION=$VERSION_NUMBER \
-    clean archive | xcpretty
+    clean archive
 xcodebuild \
     -archivePath "$ARCHIVE_PATH" \
     -exportArchive \
@@ -196,7 +196,7 @@ xcode_project \
     OTHER_CODE_SIGN_FLAGS="--keychain=\"${KEYCHAIN_PATH}\"" \
     BUILD_NUMBER=$BUILD_NUMBER \
     MARKETING_VERSION=$VERSION_NUMBER \
-    clean archive | xcpretty
+    clean archive
 xcodebuild \
     -archivePath "$ARCHIVE_PATH" \
     -exportArchive \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -140,8 +140,8 @@ echo "$TEMPORARY_KEYCHAIN_PASSWORD" | build-tools create-keychain "$KEYCHAIN_PAT
 function cleanup {
     # Cleanup the temporary files and keychain.
     cd "$ROOT_DIRECTORY"
-    build-tools delete-keychain "$KEYCHAIN_PATH"
-    rm -rf "$TEMPORARY_DIRECTORY"
+    # build-tools delete-keychain "$KEYCHAIN_PATH"
+    # rm -rf "$TEMPORARY_DIRECTORY"
 }
 
 trap cleanup EXIT

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -140,8 +140,8 @@ echo "$TEMPORARY_KEYCHAIN_PASSWORD" | build-tools create-keychain "$KEYCHAIN_PAT
 function cleanup {
     # Cleanup the temporary files and keychain.
     cd "$ROOT_DIRECTORY"
-    # build-tools delete-keychain "$KEYCHAIN_PATH"
-    # rm -rf "$TEMPORARY_DIRECTORY"
+    build-tools delete-keychain "$KEYCHAIN_PATH"
+    rm -rf "$TEMPORARY_DIRECTORY"
 }
 
 trap cleanup EXIT


### PR DESCRIPTION
`xcpretty` can mask a number of failures and make it harder to debug build issues; removing.