### PR TITLE
refactor(ios): Remove `PinboardError`

### DIFF
--- a/core/BookmarksCore/Common/BookmarksError.swift
+++ b/core/BookmarksCore/Common/BookmarksError.swift
@@ -33,6 +33,8 @@ public enum BookmarksError: Error, Equatable {
     case bookmarkNotFound(identifier: String)
     case bookmarkNotFound(url: URL)
     case tagNotFound(name: String)
+    
+    case inconsistentState
 
     case unauthorized
     case corrupt

--- a/core/BookmarksCore/Pinboard/Pinboard.swift
+++ b/core/BookmarksCore/Pinboard/Pinboard.swift
@@ -22,10 +22,6 @@ import Foundation
 
 public class Pinboard {
 
-    enum PinboardError: Error {
-        case inconsistentState
-    }
-
     fileprivate enum Path: String {
 
         case postsUpdate = "posts/update"
@@ -72,7 +68,7 @@ public class Pinboard {
             let task = URLSession.shared.dataTask(with: url) { data, response, error in
                 guard let data = data, let response = response as? HTTPURLResponse else {
                     guard let error = error else {
-                        completion(.failure(PinboardError.inconsistentState))
+                        completion(.failure(BookmarksError.inconsistentState))
                         return
                     }
                     completion(.failure(error))
@@ -180,7 +176,7 @@ public class Pinboard {
             let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
                 guard let data = data else {
                     guard let error = error else {
-                        completion(.failure(PinboardError.inconsistentState))
+                        completion(.failure(BookmarksError.inconsistentState))
                         return
                     }
                     completion(.failure(error))

--- a/ios/Bookmarks-iOS.xcodeproj/project.pbxproj
+++ b/ios/Bookmarks-iOS.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		D8019A182731B1B0001736DE /* Binding+mappedToBool in Sources */ = {isa = PBXBuildFile; fileRef = D8019A172731B1B0001736DE /* Binding+mappedToBool */; };
 		D8019A192731B260001736DE /* Binding+mappedToBool in Resources */ = {isa = PBXBuildFile; fileRef = D8019A172731B1B0001736DE /* Binding+mappedToBool */; };
 		D81E7484254A0D1B002336DC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81E7483254A0D1B002336DC /* ContentView.swift */; };
 		D81FBAC426B99E26004AC4A4 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81FBAC326B99E26004AC4A4 /* AboutView.swift */; };
@@ -362,7 +361,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				D832EEC724816901004C64E3 /* SettingsView.swift in Sources */,
-				D8019A182731B1B0001736DE /* Binding+mappedToBool in Sources */,
 				D81E7484254A0D1B002336DC /* ContentView.swift in Sources */,
 				D82BF6272730A0D0004978AD /* DebugView.swift in Sources */,
 				D8BDE1182551C56100C95945 /* BookmarksApp.swift in Sources */,


### PR DESCRIPTION
This includes a drive-by fix to stop treating the Binding+mappedToBool license as a source file.