### PR TITLE
fix(ios): Clean up the context menu

### DIFF
--- a/ios/Bookmarks/Interface/Bookmarks.swift
+++ b/ios/Bookmarks/Interface/Bookmarks.swift
@@ -56,7 +56,6 @@ struct Bookmarks: View {
                                     Image(systemName: "square.and.arrow.up")
                                 }
                             }
-                            Divider()
                             Button {
                                 sheet = .tags(bookmark)
                             } label: {


### PR DESCRIPTION
This change removes the divider which seems unnecessary.