### PR TITLE
fix: Incorrectly sharing internal state between UI components

### DIFF
--- a/core/Sources/BookmarksCore/Views/BookmarkCell.swift
+++ b/core/Sources/BookmarksCore/Views/BookmarkCell.swift
@@ -28,12 +28,13 @@ public struct BookmarkCell: View {
     }
 
     var bookmark: Bookmark
+    let manager: BookmarksManager
 
-    @Environment(\.manager) var manager: BookmarksManager
     @State var image: SafeImage?
     @State var publisher: AnyCancellable?
 
-    public init(bookmark: Bookmark) {
+    public init(manager: BookmarksManager, bookmark: Bookmark) {
+        self.manager = manager
         self.bookmark = bookmark
         _image = State(wrappedValue: manager.cache.object(forKey: bookmark.url.absoluteString as NSString))
     }

--- a/ios/Bookmarks/Interface/Bookmarks.swift
+++ b/ios/Bookmarks/Interface/Bookmarks.swift
@@ -66,7 +66,7 @@ struct Bookmarks: View {
         ScrollView {
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 160), spacing: 16)], spacing: 16) {
                 ForEach(bookmarksView.bookmarks) { bookmark in
-                    BookmarkCell(bookmark: bookmark)
+                    BookmarkCell(manager: manager, bookmark: bookmark)
                         .onTapGesture {
                             UIApplication.shared.open(bookmark.url)
                         }

--- a/macos/Bookmarks/Views/ContentView.swift
+++ b/macos/Bookmarks/Views/ContentView.swift
@@ -61,7 +61,7 @@ struct ContentView: View {
             ScrollView {
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 160), spacing: 8)], spacing: 8) {
                     ForEach(bookmarksView.bookmarks) { bookmark in
-                        BookmarkCell(bookmark: bookmark)
+                        BookmarkCell(manager: manager, bookmark: bookmark)
                             .shadow(color: .shadow, radius: 8)
                             .modifier(BorderedSelection(selected: selectionTracker.isSelected(item: bookmark),
                                                         firstResponder: firstResponder))


### PR DESCRIPTION
We were using a default value `BookmarksManager` when accessing the image cache in Bookmarks cells. While we were getting away with this, it resulted in a large number of warnings, at best resulted in fully spinning up an additional manager, and would likely cause significant confusion and issues in the future.