### PR TITLE
refactor: Remove macOS SwiftUI workarounds

### DIFF
--- a/macos/Bookmarks/BookmarksApp.swift
+++ b/macos/Bookmarks/BookmarksApp.swift
@@ -21,8 +21,9 @@
 import AppKit
 import SwiftUI
 
-import BookmarksCore
 import Diligence
+
+import BookmarksCore
 
 @main
 struct BookmarksApp: App {

--- a/macos/Bookmarks/Views/BorderedSelection.swift
+++ b/macos/Bookmarks/Views/BorderedSelection.swift
@@ -22,13 +22,11 @@ import SwiftUI
 
 struct BorderedSelection: ViewModifier {
 
-    @Environment(\.applicationHasFocus) var applicationHasFocus
-
     var selected: Bool
     var firstResponder: Bool
 
     var color: Color {
-        applicationHasFocus && firstResponder ? Color.accentColor : Color.unemphasizedSelectedContentBackgroundColor
+        firstResponder ? Color.accentColor : Color.unemphasizedSelectedContentBackgroundColor
     }
 
     func body(content: Content) -> some View {

--- a/macos/Bookmarks/Views/MainWindow.swift
+++ b/macos/Bookmarks/Views/MainWindow.swift
@@ -65,8 +65,6 @@ struct MainWindow: View {
                 sheet = .logIn
             }
         }
-        .observesApplicationFocus()
-        .frameAutosaveName("Main Window")
         .focusedSceneObject(windowModel)
     }
 


### PR DESCRIPTION
This change removes a legacy attempt at storing the window position and size (now supported in SwiftUI) and a focus observer that was used to desaturate selection colors on loss of focus.