### PR TITLE
feat: Support keyboard navigation and mouse selection in the macOS grid view

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "SQLite.swift"]
 	path = SQLite.swift
 	url = git@github.com:jbmorley/SQLite.swift.git
+[submodule "SelectableCollectionView"]
+	path = SelectableCollectionView
+	url = git@github.com:jbmorley/SelectableCollectionView.git

--- a/core/Sources/BookmarksCore/Common/Legal.swift
+++ b/core/Sources/BookmarksCore/Common/Legal.swift
@@ -47,6 +47,7 @@ public struct Legal {
         License("Bookmarks", author: "InSeven Limited", filename: "bookmarks-license", bundle: .module)
         License("Interact", author: "InSeven Limited", filename: "interact-license", bundle: .module)
         License("Introspect", author: "Timber Software", filename: "introspect-license", bundle: .module)
+        License("SelectableCollectionView", author: "Jason Morley", filename: "selectablecollectionview-license", bundle: .module)
         License("SQLite.swift", author: "Stephen Celis", filename: "sqlite-swift-license", bundle: .module)
         License("TFHpple", author: "Topfunky Corporation", filename: "tfhpple-license", bundle: .module)
     }

--- a/core/Sources/BookmarksCore/Licenses/selectablecollectionview-license
+++ b/core/Sources/BookmarksCore/Licenses/selectablecollectionview-license
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2022 Jason Morley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/core/Sources/BookmarksCore/Views/BookmarkCell.swift
+++ b/core/Sources/BookmarksCore/Views/BookmarkCell.swift
@@ -67,7 +67,6 @@ public struct BookmarkCell: View {
             }
         }
         .clipped()
-        .aspectRatio(4/3, contentMode: .fit)
     }
 
     public var body: some View {

--- a/ios/Bookmarks/Interface/Bookmarks.swift
+++ b/ios/Bookmarks/Interface/Bookmarks.swift
@@ -61,6 +61,7 @@ struct Bookmarks: View {
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 160), spacing: 16)], spacing: 16) {
                 ForEach(bookmarksView.bookmarks) { bookmark in
                     BookmarkCell(manager: manager, bookmark: bookmark)
+                        .aspectRatio(8/9, contentMode: .fit)
                         .onTapGesture {
                             UIApplication.shared.open(bookmark.url)
                         }

--- a/macos/Bookmarks-macOS.xcodeproj/project.pbxproj
+++ b/macos/Bookmarks-macOS.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		D8A8001D2A1F76200042C03B /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A8001C2A1F76200042C03B /* View.swift */; };
 		D8ACD7EF26BC81F7005F927A /* TokenField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8ACD7EE26BC81F7005F927A /* TokenField.swift */; };
 		D8B6E2C52620990400B2C239 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B6E2C42620990400B2C239 /* Item.swift */; };
+		D8C8584429560700004EB23E /* SelectableCollectionView in Frameworks */ = {isa = PBXBuildFile; productRef = D8C8584329560700004EB23E /* SelectableCollectionView */; };
 		D8D356D32955F06D0020C81C /* BookmarksCore in Frameworks */ = {isa = PBXBuildFile; productRef = D8D356D22955F06D0020C81C /* BookmarksCore */; };
 		D8E0202C26C2E1CC00910833 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E0202B26C2E1CC00910833 /* LoadingView.swift */; };
 		D8EB6E4526C3357F00C23B19 /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EB6E4426C3357F00C23B19 /* ErrorHandler.swift */; };
@@ -127,6 +128,7 @@
 				D8D356D32955F06D0020C81C /* BookmarksCore in Frameworks */,
 				D8A0D7662620165D00C9F190 /* Interact in Frameworks */,
 				D8FF9E9228A75D400081E57A /* Diligence in Frameworks */,
+				D8C8584429560700004EB23E /* SelectableCollectionView in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -328,6 +330,7 @@
 				D8A0D7652620165D00C9F190 /* Interact */,
 				D8FF9E9128A75D400081E57A /* Diligence */,
 				D8D356D22955F06D0020C81C /* BookmarksCore */,
+				D8C8584329560700004EB23E /* SelectableCollectionView */,
 			);
 			productName = Bookmarks;
 			productReference = D891C450261E32F90024E1A6 /* Bookmarks.app */;
@@ -811,6 +814,10 @@
 		D8A0D7652620165D00C9F190 /* Interact */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Interact;
+		};
+		D8C8584329560700004EB23E /* SelectableCollectionView */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SelectableCollectionView;
 		};
 		D8D356D22955F06D0020C81C /* BookmarksCore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/macos/Bookmarks/Views/BorderedSelection.swift
+++ b/macos/Bookmarks/Views/BorderedSelection.swift
@@ -22,24 +22,19 @@ import SwiftUI
 
 struct BorderedSelection: ViewModifier {
 
-    var selected: Bool
-    var firstResponder: Bool
+    @Environment(\.isSelected) var isSelected
+    @Environment(\.highlightState) var highlightState
 
     var color: Color {
-        firstResponder ? Color.accentColor : Color.unemphasizedSelectedContentBackgroundColor
+        return isSelected || highlightState == .forSelection ? Color.accentColor : Color.clear
     }
 
     func body(content: Content) -> some View {
-        if selected {
-            content
-                .padding(4)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 13)
-                        .stroke(color, lineWidth: 3))
-        } else {
-            content
-                .padding(4)
-        }
+        content
+            .padding(4)
+            .overlay(
+                RoundedRectangle(cornerRadius: 13)
+                    .stroke(color, lineWidth: 3))
     }
 
 }


### PR DESCRIPTION
This change switches over to using the `UICollectionView` wrapper, 'SelectableCollectionView', to get improved keyboard and mouse selection management. Hopefully this change will be short-lived and future versions of SwiftUI will offer native support for selection in grid views.