### PR TITLE
fix: Select the 'All Bookmarks' section by default

### DIFF
--- a/macos/Bookmarks/Views/SectionLink.swift
+++ b/macos/Bookmarks/Views/SectionLink.swift
@@ -31,9 +31,8 @@ struct SectionLink: View {
     }
 
     var body: some View {
-        NavigationLink(value: section) {
-            Label(section.sidebarTitle, systemImage: section.systemImage)
-        }
+        Label(section.sidebarTitle, systemImage: section.systemImage)
+            .tag(section)
     }
 
 }


### PR DESCRIPTION
Things work much more smoothly if you don't use `NavigationLink` in a `NavigationSplitView` sidebar.