### PR TITLE
fix: View favorite tags on Pinboard in the iOS app

### DIFF
--- a/core/Sources/BookmarksCore/Views/SidebarContentView.swift
+++ b/core/Sources/BookmarksCore/Views/SidebarContentView.swift
@@ -1,0 +1,75 @@
+// Copyright (c) 2020-2023 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Combine
+import SwiftUI
+
+import Interact
+
+public struct SidebarContentView: View {
+
+    @EnvironmentObject var manager: BookmarksManager
+    @EnvironmentObject var sceneModel: SceneModel
+    @EnvironmentObject var settings: Settings
+
+    public init() {
+
+    }
+
+    public var body: some View {
+        List(selection: $sceneModel.section) {
+            Section("Smart Filters") {
+                ForEach(BookmarksSection.defaultSections) { section in
+                    SectionLink(section)
+                }
+            }
+            if settings.favoriteTags.count > 0 {
+                Section("Favorite Tags") {
+                    ForEach(settings.favoriteTags.sorted(), id: \.section) { tag in
+                        SectionLink(tag.section)
+                            .contextMenu {
+                                Button {
+                                    do {
+                                        guard let user = manager.user else {
+                                            return
+                                        }
+                                        Application.open(try tag.pinboardTagUrl(for: user))
+                                    } catch {
+                                        print("Failed to open on Pinboard error \(error)")
+                                    }
+                                } label: {
+                                    Label("View on Pinboard", systemImage: "pin")
+
+                                }
+                                Divider()
+                                Button(role: .destructive) {
+                                    settings.favoriteTags = settings.favoriteTags.filter { $0 != tag }
+                                } label: {
+                                    Label("Remove from Favorites", systemImage: "star.slash")
+                                }
+                            }
+                    }
+                }
+            }
+
+        }
+    }
+
+}

--- a/ios/Bookmarks/Views/ContentView.swift
+++ b/ios/Bookmarks/Views/ContentView.swift
@@ -34,7 +34,7 @@ struct ContentView: View {
 
     var body: some View {
         NavigationSplitView {
-            Sidebar(sceneModel: sceneModel)
+            Sidebar()
         } detail: {
             if let section = sceneModel.section {
                 SectionView(manager: manager, section: section)
@@ -59,6 +59,7 @@ struct ContentView: View {
                 sheet = .logIn
             }
         }
+        .environmentObject(sceneModel)
         .focusedSceneObject(sceneModel)
     }
 }

--- a/ios/Bookmarks/Views/Sidebar.swift
+++ b/ios/Bookmarks/Views/Sidebar.swift
@@ -32,72 +32,42 @@ struct Sidebar: View {
         case tags
     }
 
-    @Environment(\.manager) var manager: BookmarksManager
     @EnvironmentObject var settings: Settings
-
-    @ObservedObject var sceneModel: SceneModel
     
     @State var sheet: Sheet?
     
     var body: some View {
-        List(selection: $sceneModel.section) {
-            Section("Smart Filters") {
-                SectionLink(.all)
-                SectionLink(.shared(false))
-                SectionLink(.shared(true))
-                SectionLink(.today)
-                SectionLink(.unread)
-                SectionLink(.untagged)
+        SidebarContentView()
+            .sheet(item: $sheet) { sheet in
+                switch sheet {
+                case .settings:
+                    NavigationView {
+                        SettingsView(settings: settings)
+                    }
+                case .tags:
+                    TagsView()
+                }
             }
+            .navigationTitle("Bookmarks")
+            .toolbar {
 
-            if settings.favoriteTags.count > 0 {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        sheet = .settings
+                    } label: {
+                        Image(systemName: "gear")
+                    }
+                }
 
-                Section("Favorites") {
-                    ForEach(settings.favoriteTags.sorted(), id: \.section) { tag in
-                        SectionLink(tag.section)
-                            .contextMenu {
-                                Button(role: .destructive) {
-                                    settings.favoriteTags = settings.favoriteTags.filter { $0 != tag }
-                                } label: {
-                                    Label("Remove from Favorites", systemImage: "star.slash")
-                                }
-                            }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        sheet = .tags
+                    } label: {
+                        Image(systemName: "tag")
                     }
                 }
 
             }
-
-        }
-        .sheet(item: $sheet) { sheet in
-            switch sheet {
-            case .settings:
-                NavigationView {
-                    SettingsView(settings: manager.settings)
-                }
-            case .tags:
-                TagsView()
-            }
-        }
-        .navigationTitle("Filters")
-        .toolbar {
-
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button {
-                    sheet = .settings
-                } label: {
-                    Image(systemName: "gear")
-                }
-            }
-
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button {
-                    sheet = .tags
-                } label: {
-                    Image(systemName: "tag")
-                }
-            }
-
-        }
     }
     
 }

--- a/macos/Bookmarks/BookmarksApp.swift
+++ b/macos/Bookmarks/BookmarksApp.swift
@@ -41,6 +41,8 @@ struct BookmarksApp: App {
 
         WindowGroup {
             ContentView(manager: manager)
+                .environmentObject(manager)
+                .environmentObject(manager.settings)
         }
         .commands {
             SidebarCommands()

--- a/macos/Bookmarks/Views/ContentView.swift
+++ b/macos/Bookmarks/Views/ContentView.swift
@@ -36,7 +36,7 @@ struct ContentView: View {
 
     var body: some View {
         NavigationSplitView {
-            Sidebar(manager: manager, tagsModel: manager.tagsModel, settings: manager.settings, sceneModel: sceneModel)
+            Sidebar()
         } detail: {
             if let section = sceneModel.section {
                 SectionView(manager: manager, section: section)
@@ -66,6 +66,7 @@ struct ContentView: View {
                 sheet = .logIn
             }
         }
+        .environmentObject(sceneModel)
         .focusedSceneObject(sceneModel)
     }
 


### PR DESCRIPTION
This change also shares sidebar content between macoS and iOS and as such corrects terminology inconsistencies between the two apps.