### PR TITLE
refactor: Explicit `ApplicationModel` lifecycle management

### DIFF
--- a/Bookmarks.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bookmarks.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -29,15 +29,6 @@
         }
       },
       {
-        "package": "Introspect",
-        "repositoryURL": "https://github.com/siteline/SwiftUI-Introspect.git",
-        "state": {
-          "branch": null,
-          "revision": "2e09be8af614401bc9f87d40093ec19ce56ccaf2",
-          "version": "0.1.3"
-        }
-      },
-      {
         "package": "WrappingHStack",
         "repositoryURL": "https://github.com/ksemianov/WrappingHStack.git",
         "state": {

--- a/core/Sources/BookmarksCore/Commands/AccountCommands.swift
+++ b/core/Sources/BookmarksCore/Commands/AccountCommands.swift
@@ -22,10 +22,10 @@ import SwiftUI
 
 public struct AccountCommands: Commands {
 
-    @Environment(\.applicationModel) var applicationModel: ApplicationModel
+    var applicationModel: ApplicationModel
 
-    public init() {
-
+    public init(applicationModel: ApplicationModel) {
+        self.applicationModel = applicationModel
     }
 
     public var body: some Commands {

--- a/core/Sources/BookmarksCore/Common/ApplicationModel.swift
+++ b/core/Sources/BookmarksCore/Common/ApplicationModel.swift
@@ -23,17 +23,6 @@ import SwiftUI
 
 import Interact
 
-public struct ApplicationModelEnvironmentKey: EnvironmentKey {
-    public static var defaultValue = ApplicationModel()
-}
-
-public extension EnvironmentValues {
-    var applicationModel: ApplicationModel {
-        get { self[ApplicationModelEnvironmentKey.self] }
-        set { self[ApplicationModelEnvironmentKey.self] = newValue }
-    }
-}
-
 public class ApplicationModel: ObservableObject {
 
     public enum State {

--- a/core/Sources/BookmarksCore/Common/Legal.swift
+++ b/core/Sources/BookmarksCore/Common/Legal.swift
@@ -47,7 +47,6 @@ public struct Legal {
         License("Bookmarks", author: "InSeven Limited", filename: "bookmarks-license", bundle: .module)
         License("HashRainbow", author: "Sarah Barbour", filename: "hashrainbow-license", bundle: .module)
         License("Interact", author: "InSeven Limited", filename: "interact-license", bundle: .module)
-        License("Introspect", author: "Timber Software", filename: "introspect-license", bundle: .module)
         License("SelectableCollectionView", author: "Jason Morley", filename: "selectablecollectionview-license", bundle: .module)
         License("SQLite.swift", author: "Stephen Celis", filename: "sqlite-swift-license", bundle: .module)
         License("TFHpple", author: "Topfunky Corporation", filename: "tfhpple-license", bundle: .module)

--- a/core/Sources/BookmarksCore/Licenses/introspect-license
+++ b/core/Sources/BookmarksCore/Licenses/introspect-license
@@ -1,7 +1,0 @@
-Copyright 2019 Timber Software
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/core/Sources/BookmarksCore/Views/TagsContentView.swift
+++ b/core/Sources/BookmarksCore/Views/TagsContentView.swift
@@ -24,8 +24,9 @@ import Interact
 
 public struct TagsContentView: View {
 
-    @StateObject var model: TagsContentViewModel
     @EnvironmentObject var applicationModel: ApplicationModel
+
+    @StateObject var model: TagsContentViewModel
 
     public init(tagsModel: TagsModel) {
         _model = StateObject(wrappedValue: TagsContentViewModel(tagsModel: tagsModel))

--- a/ios/Bookmarks-iOS.xcodeproj/project.pbxproj
+++ b/ios/Bookmarks-iOS.xcodeproj/project.pbxproj
@@ -20,7 +20,6 @@
 		D871B4E5273242ED00712182 /* EditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D871B4E4273242ED00712182 /* EditView.swift */; };
 		D8743909273106C000B676A5 /* Diligence in Frameworks */ = {isa = PBXBuildFile; productRef = D8743908273106C000B676A5 /* Diligence */; };
 		D8BDE1182551C56100C95945 /* BookmarksApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BDE1172551C56100C95945 /* BookmarksApp.swift */; };
-		D8BDE1472554782000C95945 /* Introspect in Frameworks */ = {isa = PBXBuildFile; productRef = D8BDE1462554782000C95945 /* Introspect */; };
 		D8D3BC0121C6AEBD00D6FB97 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D8D3BC0021C6AEBD00D6FB97 /* Assets.xcassets */; };
 		D8D3BC0421C6AEBD00D6FB97 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D8D3BC0221C6AEBD00D6FB97 /* LaunchScreen.storyboard */; };
 		D8D3BC0F21C6AEBD00D6FB97 /* BookmarksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D3BC0E21C6AEBD00D6FB97 /* BookmarksTests.swift */; };
@@ -86,7 +85,6 @@
 				D864E47121C93FD200EAB9AD /* libxml2.2.tbd in Frameworks */,
 				D8743909273106C000B676A5 /* Diligence in Frameworks */,
 				D822159B2955C35C0087FBAC /* BookmarksCore in Frameworks */,
-				D8BDE1472554782000C95945 /* Introspect in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -216,7 +214,6 @@
 			);
 			name = Bookmarks;
 			packageProductDependencies = (
-				D8BDE1462554782000C95945 /* Introspect */,
 				D8743908273106C000B676A5 /* Diligence */,
 				D822159A2955C35C0087FBAC /* BookmarksCore */,
 			);
@@ -295,7 +292,6 @@
 			);
 			mainGroup = D8D3BBED21C6AEBC00D6FB97;
 			packageReferences = (
-				D8BDE1452554782000C95945 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 			);
 			productRefGroup = D8D3BBF721C6AEBC00D6FB97 /* Products */;
 			projectDirPath = "";
@@ -695,17 +691,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		D8BDE1452554782000C95945 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/siteline/SwiftUI-Introspect.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.1;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
 		D822159A2955C35C0087FBAC /* BookmarksCore */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -714,11 +699,6 @@
 		D8743908273106C000B676A5 /* Diligence */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Diligence;
-		};
-		D8BDE1462554782000C95945 /* Introspect */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = D8BDE1452554782000C95945 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
-			productName = Introspect;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ios/Bookmarks/BookmarksApp.swift
+++ b/ios/Bookmarks/BookmarksApp.swift
@@ -25,8 +25,14 @@ import BookmarksCore
 @main
 struct BookmarksApp: App {
 
-    @Environment(\.applicationModel) var applicationModel: ApplicationModel
     @Environment(\.scenePhase) private var phase
+
+    var applicationModel: ApplicationModel
+
+    init() {
+        applicationModel = ApplicationModel()
+        applicationModel.start()
+    }
 
     var body: some Scene {
         WindowGroup {

--- a/ios/Bookmarks/Views/DebugSettingsView.swift
+++ b/ios/Bookmarks/Views/DebugSettingsView.swift
@@ -24,7 +24,7 @@ import BookmarksCore
 
 struct DebugSettingsView: View {
 
-    @Environment(\.applicationModel) var applicationModel: ApplicationModel
+    @EnvironmentObject var applicationModel: ApplicationModel
 
     @ObservedObject var settings: Settings
 

--- a/ios/Bookmarks/Views/EditView.swift
+++ b/ios/Bookmarks/Views/EditView.swift
@@ -30,9 +30,10 @@ struct EditView: View {
     enum SheetType {
         case addTag
     }
-    
-    @Environment(\.applicationModel) var applicationModel: ApplicationModel
-    @Environment(\.presentationMode) var presentationMode
+
+    @Environment(\.dismiss) var dismiss
+
+    @EnvironmentObject var applicationModel: ApplicationModel
     
     @ObservedObject var tagsModel: TagsModel
     var bookmark: Bookmark
@@ -65,7 +66,7 @@ struct EditView: View {
             DispatchQueue.main.async {
                 switch result {
                 case .success():
-                    presentationMode.wrappedValue.dismiss()
+                    dismiss()
                 case .failure(let error):
                     print("Failed to save with error \(error)")
                 }
@@ -110,7 +111,7 @@ struct EditView: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button {
-                        presentationMode.wrappedValue.dismiss()
+                        dismiss()
                     } label: {
                         Text("Cancel")
                     }

--- a/ios/Bookmarks/Views/LogInView.swift
+++ b/ios/Bookmarks/Views/LogInView.swift
@@ -22,7 +22,6 @@ import Combine
 import SwiftUI
 
 import BookmarksCore
-import Introspect
 
 struct LogInView: View {
     
@@ -31,8 +30,7 @@ struct LogInView: View {
         case password
     }
 
-    @Environment(\.applicationModel) var applicationModel
-    @Environment(\.presentationMode) var presentationMode
+    @EnvironmentObject var applicationModel: ApplicationModel
 
     @FocusState private var focus: Field?
     @State private var username: String = ""
@@ -97,9 +95,7 @@ struct LogInView: View {
             Alert(error: error)
         }
         .navigationViewStyle(.stack)
-        .introspectViewController { navigationController in
-            navigationController.isModalInPresentation = true
-        }
+        .interactiveDismissDisabled(true)
     }
 
 }

--- a/ios/Bookmarks/Views/SettingsView.swift
+++ b/ios/Bookmarks/Views/SettingsView.swift
@@ -35,8 +35,9 @@ struct SettingsView: View {
         case success(message: String)
     }
 
-    @Environment(\.applicationModel) var applicationModel: ApplicationModel
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.dismiss) var dismiss
+
+    @EnvironmentObject var applicationModel: ApplicationModel
 
     @ObservedObject var settings: Settings
     @State var sheet: SheetType?
@@ -63,7 +64,7 @@ struct SettingsView: View {
                 }
                 Section {
                     Button {
-                        presentationMode.wrappedValue.dismiss()
+                        dismiss()
                         applicationModel.logout { _ in }
                     } label: {
                         Text("Log Out")
@@ -72,12 +73,18 @@ struct SettingsView: View {
             }
         }
         .navigationBarTitle("Settings", displayMode: .inline)
-        .navigationBarItems(trailing: Button {
-            presentationMode.wrappedValue.dismiss()
-        } label: {
-            Text("Done")
-                .bold()
-        })
+        .toolbar {
+
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Done")
+                        .bold()
+                }
+            }
+
+        }
         .sheet(item: $sheet) { sheet in
             switch sheet {
             case .about:

--- a/ios/Bookmarks/Views/TagsView.swift
+++ b/ios/Bookmarks/Views/TagsView.swift
@@ -24,9 +24,9 @@ import BookmarksCore
 
 struct TagsView: View {
 
-    @EnvironmentObject var applicationModel: ApplicationModel
-
     @Environment(\.dismiss) var dismiss
+
+    @EnvironmentObject var applicationModel: ApplicationModel
 
     var body: some View {
         NavigationView {

--- a/macos/Bookmarks/BookmarksApp.swift
+++ b/macos/Bookmarks/BookmarksApp.swift
@@ -28,9 +28,10 @@ import BookmarksCore
 @main
 struct BookmarksApp: App {
 
-    @Environment(\.applicationModel) var applicationModel
+    var applicationModel: ApplicationModel
 
     init() {
+        applicationModel = ApplicationModel()
         applicationModel.start()
     }
 
@@ -50,16 +51,19 @@ struct BookmarksApp: App {
             SectionCommands()
             ViewCommands(sectionViewModel: sectionViewModel)
             BookmarkCommands()
-            AccountCommands()
+            AccountCommands(applicationModel: applicationModel)
         }
 
         SwiftUI.Settings {
             SettingsView()
+                .environmentObject(applicationModel)
+                .environmentObject(applicationModel.settings)
         }
 
         Window("Tags", id: "tags") {
             TagsContentView(tagsModel: applicationModel.tagsModel)
                 .environmentObject(applicationModel)
+                .environmentObject(applicationModel.settings)
         }
 
         About(Legal.contents)

--- a/macos/Bookmarks/Toolbars/AccountToolbar.swift
+++ b/macos/Bookmarks/Toolbars/AccountToolbar.swift
@@ -24,7 +24,7 @@ import BookmarksCore
 
 struct AccountToolbar: CustomizableToolbarContent {
 
-    @Environment(\.applicationModel) var applicationModel: ApplicationModel
+    @EnvironmentObject var applicationModel: ApplicationModel
 
     var body: some CustomizableToolbarContent {
 

--- a/macos/Bookmarks/Views/LogInView.swift
+++ b/macos/Bookmarks/Views/LogInView.swift
@@ -25,7 +25,8 @@ import BookmarksCore
 struct LogInView: View {
 
     @Environment(\.openURL) var openURL
-    @Environment(\.applicationModel) var applicationModel
+
+    @EnvironmentObject var applicationModel: ApplicationModel
 
     @State var username: String = ""
     @State var password: String = ""

--- a/macos/Bookmarks/Views/RenameTagView.swift
+++ b/macos/Bookmarks/Views/RenameTagView.swift
@@ -24,8 +24,9 @@ import BookmarksCore
 
 struct RenameTagView: View {
 
-    @Environment(\.applicationModel) var applicationModel: ApplicationModel
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.dismiss) var dismiss
+
+    @EnvironmentObject var applicationModel: ApplicationModel
 
     @State var tag: String
     @State var isBusy = false
@@ -46,7 +47,7 @@ struct RenameTagView: View {
                 HStack {
                     Spacer()
                     Button("Cancel") {
-                        presentationMode.wrappedValue.dismiss()
+                        dismiss()
                     }
                     .keyboardShortcut(.cancelAction)
                     Button("OK") {
@@ -60,7 +61,7 @@ struct RenameTagView: View {
                                     }
                                 case .success:
                                     print("Successfully renamed tag")
-                                    presentationMode.wrappedValue.dismiss()
+                                    dismiss()
                                 }
                             }
                         }

--- a/macos/Bookmarks/Views/SettingsView.swift
+++ b/macos/Bookmarks/Views/SettingsView.swift
@@ -29,7 +29,7 @@ struct SettingsView: View {
         case account
     }
 
-    @Environment(\.applicationModel) var applicationModel: ApplicationModel
+    @EnvironmentObject var applicationModel: ApplicationModel
 
     var body: some View {
         EmptyView()

--- a/macos/Bookmarks/Views/Sidebar.swift
+++ b/macos/Bookmarks/Views/Sidebar.swift
@@ -38,7 +38,7 @@ struct Sidebar: View {
         case rename(tag: String)
     }
 
-    @Environment(\.applicationModel) var applicationModel
+    @EnvironmentObject var applicationModel: ApplicationModel
 
     @State var sheet: SheetType? = nil
 


### PR DESCRIPTION
This change also includes a drive-by fix to remove the now-unnecessary Introspect library and migrate to the new SwiftUI `dismiss` environment variable.