### PR TITLE
chore: Bookmarks for Safari local build version should match main app

### DIFF
--- a/macos/Bookmarks-macOS.xcodeproj/project.pbxproj
+++ b/macos/Bookmarks-macOS.xcodeproj/project.pbxproj
@@ -570,7 +570,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.3;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.0.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -605,7 +605,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.3;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.0.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,


### PR DESCRIPTION
Local builds show a warning without this.