### PR TITLE
feat: Keyboard shortcuts on iPad

### DIFF
--- a/core/Sources/BookmarksCore/Commands/ApplicationCommands.swift
+++ b/core/Sources/BookmarksCore/Commands/ApplicationCommands.swift
@@ -20,10 +20,9 @@
 
 import SwiftUI
 
-#if os(macOS)
-
 public struct ApplicationCommands: Commands {
 
+    @FocusedObject var sceneModel: SceneModel?
     @Environment(\.openWindow) var openWindow
 
     public init() {
@@ -33,7 +32,11 @@ public struct ApplicationCommands: Commands {
     public var body: some Commands {
         CommandGroup(before: .appSettings) {
             Button {
+#if os(macOS)
                 openWindow(id: TagsWindow.identifier)
+#else
+                sceneModel?.showTags()
+#endif
             } label: {
                 Text("Tags...")
             }
@@ -43,5 +46,3 @@ public struct ApplicationCommands: Commands {
     }
 
 }
-
-#endif

--- a/core/Sources/BookmarksCore/Commands/ViewCommands.swift
+++ b/core/Sources/BookmarksCore/Commands/ViewCommands.swift
@@ -22,6 +22,25 @@ import SwiftUI
 
 public struct ViewCommands: Commands {
 
+    struct Content: Commands {
+
+        @ObservedObject var sectionViewModel: SectionViewModel
+
+        var body: some Commands {
+            CommandGroup(before: .sidebar) {
+                ForEach(LayoutMode.allCases) { layoutMode in
+                    Toggle(isOn: $sectionViewModel.layoutMode.equals(layoutMode)) {
+                        Label(Localized(layoutMode), systemImage: layoutMode.systemImage)
+                    }
+                    .help(Localized(layoutMode))
+                    .keyboardShortcut(layoutMode.keyboardShortcut, modifiers: .command)
+                }
+                .disabled(sectionViewModel.isPlaceholder)
+                Divider()
+            }
+        }
+    }
+
     @FocusedObject var sectionViewModel: SectionViewModel?
 
     public init() {
@@ -29,10 +48,7 @@ public struct ViewCommands: Commands {
     }
 
     public var body: some Commands {
-        CommandGroup(before: .sidebar) {
-            LayoutPicker()
-                .environmentObject(sectionViewModel ?? SectionViewModel())
-        }
+        Content(sectionViewModel: sectionViewModel ?? SectionViewModel())
     }
 
 }

--- a/core/Sources/BookmarksCore/Extensions/Binding.swift
+++ b/core/Sources/BookmarksCore/Extensions/Binding.swift
@@ -34,12 +34,30 @@ extension Binding where Value == Bool {
         }
     }
 
+    init<T: Equatable>(_ binding: Binding<T>, equals value: T) {
+        self.init {
+            binding.wrappedValue == value
+        } set: { active in
+            if active {
+                binding.wrappedValue = value
+            }
+        }
+    }
+
 }
 
 extension Binding where Value == Array<String> {
 
     func contains(_ value: String) -> Binding<Bool> {
         return Binding<Bool>(self, contains: value)
+    }
+
+}
+
+extension Binding where Value: Equatable {
+
+    func equals(_ value: Value) -> Binding<Bool> {
+        return Binding<Bool>(self, equals: value)
     }
 
 }

--- a/core/Sources/BookmarksCore/Extensions/Scene.swift
+++ b/core/Sources/BookmarksCore/Extensions/Scene.swift
@@ -20,32 +20,21 @@
 
 import SwiftUI
 
-public struct AccountCommands: Commands {
+extension Scene {
 
-    var applicationModel: ApplicationModel
+    public func commonCommands(applicationModel: ApplicationModel) -> some Scene {
+        commands {
 
-    public init(applicationModel: ApplicationModel) {
-        self.applicationModel = applicationModel
-    }
+            SidebarCommands()
+            ToolbarCommands()
 
-    public var body: some Commands {
+            AccountCommands(applicationModel: applicationModel)
+            ApplicationCommands()
+            SectionCommands()
+            ViewCommands()
+            BookmarkCommands()
 
-        CommandMenu("Account") {
-            Button("Log Out...") {
-                applicationModel.logout { _ in }
-            }
         }
-
-        CommandGroup(after: .newItem) {
-            Divider()
-            Button("Refresh") {
-                Task {
-                    await applicationModel.refresh()
-                }
-            }
-            .keyboardShortcut("r", modifiers: .command)
-        }
-        
     }
 
 }

--- a/core/Sources/BookmarksCore/Model/LayoutMode.swift
+++ b/core/Sources/BookmarksCore/Model/LayoutMode.swift
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import Foundation
+import SwiftUI
 
 public enum LayoutMode: String, CaseIterable, Identifiable {
 
@@ -33,6 +33,15 @@ public enum LayoutMode: String, CaseIterable, Identifiable {
             return "square.grid.2x2"
         case .table:
             return "list.bullet"
+        }
+    }
+
+    var keyboardShortcut: KeyEquivalent {
+        switch self {
+        case .grid:
+            return "j"
+        case .table:
+            return "k"
         }
     }
 

--- a/ios/Bookmarks/BookmarksApp.swift
+++ b/ios/Bookmarks/BookmarksApp.swift
@@ -43,6 +43,7 @@ struct BookmarksApp: App {
                 .environmentObject(applicationModel)
                 .environmentObject(applicationModel.settings)
         }
+        .commonCommands(applicationModel: applicationModel)
         .onChange(of: phase) { phase in
             switch phase {
             case .active:

--- a/macos/Bookmarks/BookmarksApp.swift
+++ b/macos/Bookmarks/BookmarksApp.swift
@@ -45,15 +45,7 @@ struct BookmarksApp: App {
                 .environmentObject(applicationModel)
                 .environmentObject(applicationModel.settings)
         }
-        .commands {
-            SidebarCommands()
-            ToolbarCommands()
-            AccountCommands(applicationModel: applicationModel)
-            ApplicationCommands()
-            SectionCommands()
-            ViewCommands()
-            BookmarkCommands()
-        }
+        .commonCommands(applicationModel: applicationModel)
 
         SwiftUI.Settings {
             SettingsView()


### PR DESCRIPTION
This change also introduces a keyboard shortcut to refresh the account (Cmd+R) on macOS.