### PR TITLE
refactor: Incremental improvements to the `Updater` architecture

### DIFF
--- a/core/Sources/BookmarksCore/Commands/BookmarkEditCommands.swift
+++ b/core/Sources/BookmarksCore/Commands/BookmarkEditCommands.swift
@@ -39,7 +39,7 @@ struct BookmarkEditCommands: View {
         .disabled(sectionViewModel.selection.isEmpty)
 
         Button(containsPublicBookmark ? "Make Private" : "Make Public") {
-            sectionViewModel.update(shared: !containsPublicBookmark)
+            await sectionViewModel.update(shared: !containsPublicBookmark)
         }
         .keyboardShortcut("p", modifiers: [.command, .shift])
         .disabled(sectionViewModel.selection.isEmpty)

--- a/core/Sources/BookmarksCore/Common/ApplicationModel.swift
+++ b/core/Sources/BookmarksCore/Common/ApplicationModel.swift
@@ -142,53 +142,19 @@ public class ApplicationModel: ObservableObject {
 
     public func refresh() async {
         return await withCheckedContinuation { continuation in
-            updater.update(force: true) { error in
+            updater.refresh(force: true) { error in
                 // N.B. We ignore the error here as it is currently handled via the delegate callback mechanism.
                 continuation.resume()
             }
         }
     }
-
-    public func deleteBookmarks(_ bookmarks: [Bookmark], completion: @escaping (Result<Void, Error>) -> Void) {
-        updater.deleteBookmarks(bookmarks, completion: completion)
-    }
-
-    public func deleteBookmarks(_ bookmarks: Set<Bookmark>, completion: @escaping (Result<Void, Error>) -> Void) {
-        updater.deleteBookmarks(Array(bookmarks), completion: completion)
-    }
     
-    public func deleteBookmarks(_ bookmarks: [Bookmark]) async throws {
-        return try await withCheckedThrowingContinuation { continuation in
-            updater.deleteBookmarks(bookmarks) { result in
-                switch result {
-                case .success:
-                    continuation.resume()
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
+    public func delete(bookmarks: [Bookmark]) async throws {
+        try await updater.delete(bookmarks: bookmarks)
     }
 
-    public func updateBookmarks(_ bookmarks: [Bookmark], completion: @escaping (Result<Void, Error>) -> Void) {
-        updater.updateBookmarks(bookmarks, completion: completion)
-    }
-
-    public func updateBookmarks(_ bookmarks: Set<Bookmark>, completion: @escaping (Result<Void, Error>) -> Void) {
-        updater.updateBookmarks(Array(bookmarks), completion: completion)
-    }
-    
-    public func updateBookmarks(_ bookmarks: [Bookmark]) async throws {
-        return try await withCheckedThrowingContinuation { continuation in
-            updater.updateBookmarks(bookmarks) { result in
-                switch result {
-                case .success:
-                    continuation.resume()
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
+    public func update(bookmarks: [Bookmark]) async throws {
+        try await updater.update(bookmarks: bookmarks)
     }
 
     public func renameTag(_ old: String, to new: String, completion: @escaping (Result<Void, Error>) -> Void) {
@@ -227,7 +193,7 @@ public class ApplicationModel: ObservableObject {
     }
 
     @objc func nsApplicationDidBecomeActive() {
-        self.updater.update()
+        self.updater.refresh()
     }
 
 }

--- a/core/Sources/BookmarksCore/Common/RemoteOperation.swift
+++ b/core/Sources/BookmarksCore/Common/RemoteOperation.swift
@@ -1,0 +1,107 @@
+// Copyright (c) 2020-2023 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+// TODO: Should the title be a type? Or a localizable key?
+// TODO: Perhaps the kind should be templated.
+
+protocol RemoteOperation {
+
+    var title: String { get }
+
+    func perform(database: Database, state: Updater.ServiceState) async throws -> Updater.ServiceState
+
+}
+
+struct RefreshOperation: RemoteOperation {
+
+    let title = "Update"
+
+    let force: Bool
+
+    func perform(database: Database, state: Updater.ServiceState) async throws -> Updater.ServiceState {
+        let pinboard = Pinboard(token: state.token)
+        let update = try pinboard.postsUpdate()
+        if let lastUpdate = state.lastUpdate,
+           lastUpdate >= update.updateTime,
+           !force {
+            print("skipping empty update")
+            return state
+        }
+
+        // Get the posts.
+        let posts = try pinboard.postsAll()
+
+        var identifiers = Set<String>()
+
+        // Insert or update bookmarks.
+        for post in posts {
+            guard let bookmark = Bookmark(post) else {
+                continue
+            }
+            identifiers.insert(bookmark.identifier)
+            _ = try database.insertOrUpdateBookmark(bookmark)
+        }
+
+        // Delete missing bookmarks.
+        let allIdentifiers = try database.identifiers()
+        let deletedIdentifiers = Set(allIdentifiers).subtracting(identifiers)
+        for identifier in deletedIdentifiers {
+            let bookmark = try database.bookmarkSync(identifier: identifier)
+            print("deleting \(bookmark)...")
+            _ = try database.deleteBookmark(identifier: identifier)
+        }
+        print("update complete")
+
+        // Update the last update date.
+        var newState = state
+        newState.lastUpdate = update.updateTime
+        return newState
+    }
+
+}
+
+struct UpdateBookmark: RemoteOperation {
+
+    let title = "Update bookmark"
+    let bookmark: Bookmark
+
+    func perform(database: Database, state: Updater.ServiceState) async throws -> Updater.ServiceState {
+        let pinboard = Pinboard(token: state.token)
+        let post = Pinboard.Post(bookmark)
+        try pinboard.postsAdd(post: post, replace: true)
+        return state
+    }
+
+}
+
+struct DeleteBookmark: RemoteOperation {
+
+    let title = "Delete bookmark"
+    let bookmark: Bookmark
+
+    func perform(database: Database, state: Updater.ServiceState) async throws -> Updater.ServiceState {
+        let pinboard = Pinboard(token: state.token)
+        try pinboard.postsDelete(url: bookmark.url)
+        return state
+    }
+
+}

--- a/core/Sources/BookmarksCore/Model/EditViewModel.swift
+++ b/core/Sources/BookmarksCore/Model/EditViewModel.swift
@@ -92,15 +92,12 @@ public class EditViewModel: ObservableObject, Runnable {
                 }
                 var bookmark = update
                 bookmark.tags = Set(tags)
-                self.applicationModel.updateBookmarks([bookmark]) { result in
-                    DispatchQueue.main.async {
-                        if case let .failure(error) = result {
-                            self.error = error
-                        }
-                        // Update our world-view so we can track other changes.
-                        // N.B. There is a race condition here; if the user makes changes too quickly it will get out
-                        // of sync.
+                Task {
+                    do {
+                        try await self.applicationModel.update(bookmarks: [bookmark])
                         self.bookmark = bookmark
+                    } catch {
+                        self.error = error
                     }
                 }
             }

--- a/core/Sources/BookmarksCore/Model/SectionViewModel.swift
+++ b/core/Sources/BookmarksCore/Model/SectionViewModel.swift
@@ -43,7 +43,7 @@ public class SectionViewModel: ObservableObject, Runnable {
     @Published public var selection: Set<Bookmark.ID> = []
     @Published public var previewURL: URL? = nil
 
-    @Published public var lastError: Error? = nil
+    @MainActor @Published public var lastError: Error? = nil
 
     @Published private var query: AnyQuery
     @Published private var bookmarksLookup: [Bookmark.ID: Bookmark] = [:]
@@ -224,30 +224,45 @@ public class SectionViewModel: ObservableObject, Runnable {
         return bookmarks.map { $0.url }
     }
 
+    // TODO: Make this async?
     @MainActor public func update(ids: Set<Bookmark.ID>? = nil, toRead: Bool) {
         guard let applicationModel else {
             return
         }
         let bookmarks = bookmarks(for: ids)
             .map { $0.setting(toRead: toRead) }
-        applicationModel.updateBookmarks(bookmarks, completion: errorHandler())
+        Task {
+            do {
+                try await applicationModel.update(bookmarks: bookmarks)
+            } catch {
+                self.lastError = error
+            }
+        }
     }
 
-    @MainActor public func update(ids: Set<Bookmark.ID>? = nil, shared: Bool) {
+    @MainActor public func update(ids: Set<Bookmark.ID>? = nil, shared: Bool) async {
         guard let applicationModel else {
             return
         }
         let bookmarks = bookmarks(for: ids)
             .map { $0.setting(shared: shared) }
-        applicationModel.updateBookmarks(bookmarks, completion: errorHandler())
+        do {
+            try await applicationModel.update(bookmarks: bookmarks)
+        } catch {
+            self.lastError = error
+        }
     }
 
-    @MainActor public func delete(ids: Set<Bookmark.ID>? = nil) {
+    @MainActor public func delete(ids: Set<Bookmark.ID>? = nil) async {
         guard let applicationModel else {
             return
         }
         let bookmarks = bookmarks(for: ids)
-        applicationModel.deleteBookmarks(bookmarks, completion: errorHandler())
+        do {
+            try await applicationModel.delete(bookmarks: bookmarks)
+        } catch {
+            self.lastError = error
+        }
     }
 
     @MainActor public func copy(ids: Set<Bookmark.ID>? = nil) {
@@ -317,7 +332,9 @@ public class SectionViewModel: ObservableObject, Runnable {
         }
         MenuItem(containsPublicBookmark ? "Make Private" : "Make Public",
                  systemImage: containsPublicBookmark ? "lock": "globe") {
-            self.update(ids: selection, shared: !containsPublicBookmark)
+            Task {
+                await self.update(ids: selection, shared: !containsPublicBookmark)
+            }
         }
         Divider()
         MenuItem("Copy", systemImage: "doc.on.doc") {
@@ -328,7 +345,9 @@ public class SectionViewModel: ObservableObject, Runnable {
         }
         Divider()
         MenuItem("Delete", systemImage: "trash", role: .destructive) {
-            self.delete(ids: selection)
+            Task {
+                await self.delete(ids: selection)
+            }
         }
     }
 

--- a/core/Sources/BookmarksCore/Pinboard/Post.swift
+++ b/core/Sources/BookmarksCore/Pinboard/Post.swift
@@ -93,3 +93,23 @@ extension Pinboard {
     }
 
 }
+
+extension Bookmark {
+
+    init?(_ post: Pinboard.Post) {
+        guard
+            let url = post.href,
+            let date = post.time else {
+                return nil
+        }
+        self.init(identifier: post.hash,
+                  title: post.description ?? "",
+                  url: url,
+                  tags: Set(post.tags),
+                  date: date,
+                  toRead: post.toRead,
+                  shared: post.shared,
+                  notes: post.extended)
+    }
+
+}

--- a/core/Sources/BookmarksCore/Toolbars/SelectionToolbar.swift
+++ b/core/Sources/BookmarksCore/Toolbars/SelectionToolbar.swift
@@ -51,7 +51,7 @@ public struct SelectionToolbar: CustomizableToolbarContent {
 
             ToolbarItem(id: "delete") {
                 Button {
-                    sectionViewModel.delete()
+                    await sectionViewModel.delete()
                 } label: {
                     Label("Delete", systemImage: "trash")
                 }


### PR DESCRIPTION
This change starts to make remote update operations more explicit by introducing a new `RemoteOperation` protocol and enqueues instances of this protocol to schedule remote updates following local changes. Future updates should make these operations serializable and write the pending update queue to disk to allow for offline changes.