### PR TITLE
fix: Rename bookmark 'Edit' to 'Get Info'

### DIFF
--- a/core/Sources/BookmarksCore/Commands/BookmarkEditCommands.swift
+++ b/core/Sources/BookmarksCore/Commands/BookmarkEditCommands.swift
@@ -46,13 +46,13 @@ struct BookmarkEditCommands: View {
 
         Divider()
 
-        Button("Edit") {
+        Button("Get Info") {
             for id in sectionViewModel.selection {
                 openWindow(value: id)
             }
         }
         .disabled(sectionViewModel.selection.isEmpty)
-        .keyboardShortcut("e", modifiers: [.command])
+        .keyboardShortcut("i", modifiers: [.command])
 
     }
 

--- a/core/Sources/BookmarksCore/Model/SectionViewModel.swift
+++ b/core/Sources/BookmarksCore/Model/SectionViewModel.swift
@@ -314,12 +314,12 @@ public class SectionViewModel: ObservableObject, Runnable {
         Divider()
 #if os(iOS)
         if bookmarks.count == 1, let bookmark = bookmarks.first {
-            MenuItem("Edit", systemImage: "square.and.pencil") {
+            MenuItem("Get Info", systemImage: "square.and.pencil") {
                 self.sceneModel?.edit(bookmark)
             }
         }
 #else
-        MenuItem("Edit", systemImage: "square.and.pencil") {
+        MenuItem("Get Info", systemImage: "square.and.pencil") {
             for id in selection {
                 openWindow?(value: id)
             }


### PR DESCRIPTION
This change also updates the keyboard shortcut to Cmd+I to match.