### PR TITLE
fix: Improve visibility of tags

### DIFF
--- a/core/Sources/BookmarksCore/Extensions/Array.swift
+++ b/core/Sources/BookmarksCore/Extensions/Array.swift
@@ -22,7 +22,7 @@ import SwiftUI
 
 extension Array where Element == Color {
 
-    static let system: [Color] = [
+    static let html: [Color] = [
         .HTML.aliceBlue,
         .HTML.antiqueWhite,
         .HTML.aqua,
@@ -172,5 +172,17 @@ extension Array where Element == Color {
         .HTML.yellow,
         .HTML.yellowGreen,
     ]
+
+    static let tags: [Color] = {
+        return html.filter { color in
+            guard let gray = color.gray,
+                  gray < 0.9,
+                  gray > 0.1
+            else {
+                return false
+            }
+            return true
+        }
+    }()
 
 }

--- a/core/Sources/BookmarksCore/Extensions/Color.swift
+++ b/core/Sources/BookmarksCore/Extensions/Color.swift
@@ -204,6 +204,12 @@ extension Color {
         Color(.sRGBLinear, white: 0, opacity: 0.12)
     }
 
+    var gray: CGFloat? {
+        return cgColor?.converted(to: CGColorSpaceCreateDeviceGray(),
+                                  intent: CGColorRenderingIntent.defaultIntent,
+                                  options: nil)?.components?.first
+    }
+
     init(_ value: Int32) {
         let red = Double(((0xff << 16) & value) >> 16)
         let green = Double(((0xff << 8) & value) >> 8)

--- a/core/Sources/BookmarksCore/Extensions/String.swift
+++ b/core/Sources/BookmarksCore/Extensions/String.swift
@@ -47,7 +47,7 @@ extension String: Identifiable {
     }
 
     public func color() -> Color {
-        return HashRainbow.colorForString(self, colors: .system)
+        return HashRainbow.colorForString(self, colors: .tags)
     }
 
     public func containsWhitespaceAndNewlines() -> Bool {


### PR DESCRIPTION
This change introduces some rudimentary filtering of the candidate colors to omit ones which are likely to be difficult to see on dark and light backgrounds.