### PR TITLE
fix: Only use a progress bar when showing update progress

### DIFF
--- a/core/Sources/BookmarksCore/Common/RemoteOperation.swift
+++ b/core/Sources/BookmarksCore/Common/RemoteOperation.swift
@@ -42,7 +42,10 @@ struct RefreshOperation: RemoteOperation {
     func perform(database: Database,
                  state: Updater.ServiceState,
                  progress: @escaping (Progress) -> Void) async throws -> Updater.ServiceState {
-        progress(.active)
+
+        // Indicate that we're about to start.
+        progress(.value(0))
+
         let pinboard = Pinboard(token: state.token)
         let update = try await pinboard.postsUpdate()
         if let lastUpdate = state.lastUpdate,

--- a/core/Sources/BookmarksCore/Common/Updater.swift
+++ b/core/Sources/BookmarksCore/Common/Updater.swift
@@ -84,9 +84,6 @@ public class Updater {
             }
         }
 
-        // Notify our delegate we're about to start.
-        progress(.active)
-
         // Ensure we can get a log in token.
         guard let token = syncQueue_token() else {
             progress(.failure(BookmarksError.unauthorized))


### PR DESCRIPTION
It's a bit visually noisy flip-flopping between 'Updating...' and a progress bar.