### PR TITLE
refactor: Rename `Updater` to `Store`

### DIFF
--- a/core/Sources/BookmarksCore/Common/ApplicationModel.swift
+++ b/core/Sources/BookmarksCore/Common/ApplicationModel.swift
@@ -42,7 +42,7 @@ public class ApplicationModel: ObservableObject {
     public var database: Database
 
     private var downloadManager: DownloadManager
-    private var updater: Updater
+    private var store: Store
     private var cancellables: Set<AnyCancellable> = []
 
     public init() {
@@ -68,11 +68,11 @@ public class ApplicationModel: ObservableObject {
         imageCache = FileImageCache(path: documentsURL.appendingPathComponent("thumbnails"))
         downloadManager = DownloadManager(limit: settings.maximumConcurrentThumbnailDownloads)
         thumbnailManager = ThumbnailManager(imageCache: imageCache, downloadManager: downloadManager)
-        updater = Updater(database: database, settings: settings)
+        store = Store(database: database, settings: settings)
         tagsModel = TagsModel(database: database)
 
-        updater.delegate = self
-        updater.start()
+        store.delegate = self
+        store.start()
         tagsModel.start()
 
         #if os(macOS)
@@ -114,7 +114,7 @@ public class ApplicationModel: ObservableObject {
                              password: String,
                              completion: @escaping (Result<Void, Error>) -> Void) {
         let completion = DispatchQueue.global().asyncClosure(completion)
-        updater.authenticate(username: username, password: password) { result in
+        store.authenticate(username: username, password: password) { result in
             DispatchQueue.main.async {
                 switch result {
                 case .success():
@@ -130,7 +130,7 @@ public class ApplicationModel: ObservableObject {
     public func logout(completion: @escaping (Result<Void, Error>) -> Void) {
         dispatchPrecondition(condition: .onQueue(.main))
         let completion = DispatchQueue.global().asyncClosure(completion)
-        updater.logout { result in
+        store.logout { result in
             DispatchQueue.main.async {
                 switch result {
                 case .success():
@@ -145,7 +145,7 @@ public class ApplicationModel: ObservableObject {
 
     public func refresh() async {
         return await withCheckedContinuation { continuation in
-            updater.refresh(force: true) { error in
+            store.refresh(force: true) { error in
                 // N.B. We ignore the error here as it is currently handled via the delegate callback mechanism.
                 continuation.resume()
             }
@@ -153,19 +153,19 @@ public class ApplicationModel: ObservableObject {
     }
     
     public func delete(bookmarks: [Bookmark]) async throws {
-        try await updater.delete(bookmarks: bookmarks)
+        try await store.delete(bookmarks: bookmarks)
     }
 
     public func update(bookmarks: [Bookmark]) async throws {
-        try await updater.update(bookmarks: bookmarks)
+        try await store.update(bookmarks: bookmarks)
     }
 
     public func rename(tag: String, to newTag: String) async throws {
-        try await updater.rename(tag: tag, to: newTag)
+        try await store.rename(tag: tag, to: newTag)
     }
 
     public func delete(tags: [String]) async throws {
-        try await updater.delete(tags: tags)
+        try await store.delete(tags: tags)
     }
 
     @MainActor public func open(_ bookmarks: Set<Bookmark>,
@@ -196,14 +196,14 @@ public class ApplicationModel: ObservableObject {
     }
 
     @objc func nsApplicationDidBecomeActive() {
-        self.updater.refresh()
+        self.store.refresh()
     }
 
 }
 
-extension ApplicationModel: UpdaterDelegate {
+extension ApplicationModel: StoreDelegate {
 
-    func updater(_ updater: Updater, didProgress progress: Progress) {
+    func store(_ store: Store, didProgress progress: Progress) {
         Task { @MainActor in
             self.progress = progress
             switch progress {

--- a/core/Sources/BookmarksCore/Common/RemoteOperation.swift
+++ b/core/Sources/BookmarksCore/Common/RemoteOperation.swift
@@ -28,8 +28,8 @@ protocol RemoteOperation {
     var title: String { get }
 
     func perform(database: Database,
-                 state: Updater.ServiceState,
-                 progress: @escaping (Progress) -> Void) async throws -> Updater.ServiceState
+                 state: Store.ServiceState,
+                 progress: @escaping (Progress) -> Void) async throws -> Store.ServiceState
 
 }
 
@@ -40,8 +40,8 @@ struct RefreshOperation: RemoteOperation {
     let force: Bool
 
     func perform(database: Database,
-                 state: Updater.ServiceState,
-                 progress: @escaping (Progress) -> Void) async throws -> Updater.ServiceState {
+                 state: Store.ServiceState,
+                 progress: @escaping (Progress) -> Void) async throws -> Store.ServiceState {
 
         // Indicate that we're about to start.
         progress(.value(0))
@@ -94,8 +94,8 @@ struct UpdateBookmark: RemoteOperation {
     let bookmark: Bookmark
 
     func perform(database: Database,
-                 state: Updater.ServiceState,
-                 progress: @escaping (Progress) -> Void) async throws -> Updater.ServiceState {
+                 state: Store.ServiceState,
+                 progress: @escaping (Progress) -> Void) async throws -> Store.ServiceState {
         let pinboard = Pinboard(token: state.token)
         let post = Pinboard.Post(bookmark)
         try await pinboard.postsAdd(post: post, replace: true)
@@ -110,8 +110,8 @@ struct DeleteBookmark: RemoteOperation {
     let bookmark: Bookmark
 
     func perform(database: Database,
-                 state: Updater.ServiceState,
-                 progress: @escaping (Progress) -> Void) async throws -> Updater.ServiceState {
+                 state: Store.ServiceState,
+                 progress: @escaping (Progress) -> Void) async throws -> Store.ServiceState {
         let pinboard = Pinboard(token: state.token)
         try await pinboard.postsDelete(url: bookmark.url)
         return state
@@ -125,8 +125,8 @@ struct DeleteTag: RemoteOperation {
     let tag: String
 
     func perform(database: Database,
-                 state: Updater.ServiceState,
-                 progress: @escaping (Progress) -> Void) async throws -> Updater.ServiceState {
+                 state: Store.ServiceState,
+                 progress: @escaping (Progress) -> Void) async throws -> Store.ServiceState {
         let pinboard = Pinboard(token: state.token)
         try await pinboard.tagsDelete(tag)
         return state
@@ -141,8 +141,8 @@ struct RenameTag: RemoteOperation {
     let newTag: String
 
     func perform(database: Database,
-                 state: Updater.ServiceState,
-                 progress: @escaping (Progress) -> Void) async throws -> Updater.ServiceState {
+                 state: Store.ServiceState,
+                 progress: @escaping (Progress) -> Void) async throws -> Store.ServiceState {
         let pinboard = Pinboard(token: state.token)
         try await pinboard.tagsRename(tag, to: newTag)
         return state

--- a/core/Sources/BookmarksCore/Common/Store.swift
+++ b/core/Sources/BookmarksCore/Common/Store.swift
@@ -20,13 +20,13 @@
 
 import Foundation
 
-protocol UpdaterDelegate: AnyObject {
+protocol StoreDelegate: AnyObject {
 
-    func updater(_ updater: Updater, didProgress progress: Progress)
+    func store(_ store: Store, didProgress progress: Progress)
 
 }
 
-public class Updater {
+public class Store {
 
     // TODO: ServiceState should be serializable and stored with each service instance.
     struct ServiceState {
@@ -36,14 +36,14 @@ public class Updater {
 
     static var updateTimeoutSeconds = 5 * 60.0
 
-    private let syncQueue = DispatchQueue(label: "Updater.syncQueue")
-    private let targetQueue = DispatchQueue(label: "Updater.targetQueue")
+    private let syncQueue = DispatchQueue(label: "Store.syncQueue")
+    private let targetQueue = DispatchQueue(label: "Store.targetQueue")
     private let database: Database
     private var timer: Timer?
 
     private var settings: Settings
     private var lastUpdate: Date? = nil  // Synchronized on syncQueue
-    weak var delegate: UpdaterDelegate?
+    weak var delegate: StoreDelegate?
 
     private func syncQueue_token() -> String? {
         dispatchPrecondition(condition: .onQueue(syncQueue))
@@ -80,7 +80,7 @@ public class Updater {
 
         let progress = { (progress: Progress) in
             self.targetQueue.async {
-                self.delegate?.updater(self, didProgress: progress)
+                self.delegate?.store(self, didProgress: progress)
             }
         }
 


### PR DESCRIPTION
Right now, change operations are written to the database _through_ the store/updater. This change renames the `Updater` to `Store` to make that setup clearer.