### PR TITLE
fix: Fetch page titles for insecure pages in the share extension

### DIFF
--- a/ios/Bookmarks Share Extension/Info.plist
+++ b/ios/Bookmarks Share Extension/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>


### PR DESCRIPTION
The share extension was blocking HTTP fetches meaning that fetching the page titles would fail for insecure domains. This change updates the Info.plist file to permit these fetches and surfaces errors when fetching titles.