### PR TITLE
fix: Update the default library section ordering

### DIFF
--- a/core/Sources/BookmarksCore/Commands/SectionCommands.swift
+++ b/core/Sources/BookmarksCore/Commands/SectionCommands.swift
@@ -22,21 +22,23 @@ import SwiftUI
 
 public struct SectionCommands: Commands {
 
+    @ObservedObject var settings: Settings
+
     @FocusedBinding(\.sceneState) var sceneState: SceneState?
 
     static func keyEquivalent(_ value: Int) -> KeyEquivalent {
         return KeyEquivalent(String(value).first!)
     }
 
-    public init() {
-        
+    public init(settings: Settings) {
+        self.settings = settings
     }
 
     public var body: some Commands {
         CommandMenu("Go") {
-            ForEach(Array(BookmarksSection.defaultSections.enumerated()), id: \.element.id) { index, section in
-                Button(section.navigationTitle) {
-                    sceneState?.section = section
+            ForEach(Array(settings.librarySections.enumerated()), id: \.element.id) { index, librarySection in
+                Button(librarySection.section.navigationTitle) {
+                    sceneState?.section = librarySection.section
                 }
                 .keyboardShortcut(Self.keyEquivalent(index + 1), modifiers: .command)
                 .disabled(sceneState == nil)

--- a/core/Sources/BookmarksCore/Common/BookmarksSection.swift
+++ b/core/Sources/BookmarksCore/Common/BookmarksSection.swift
@@ -28,15 +28,6 @@ public protocol Sectionable {
 
 public enum BookmarksSection: Equatable, Codable {
 
-    public static let defaultSections: [Self] = [
-        .all,
-        .shared(false),
-        .shared(true),
-        .today,
-        .unread,
-        .untagged,
-    ]
-
     case all
     case untagged
     case today

--- a/core/Sources/BookmarksCore/Common/Settings.swift
+++ b/core/Sources/BookmarksCore/Common/Settings.swift
@@ -19,10 +19,19 @@
 // SOFTWARE.
 
 import Foundation
+import SwiftUI
 
 import Interact
 
 final public class Settings: ObservableObject {
+
+    public struct LibrarySection: Codable, Identifiable {
+
+        public var id: BookmarksSection { section }
+
+        let section: BookmarksSection
+        let isEnabled: Bool
+    }
 
     let defaults = KeyedDefaults<SettingsKey>(defaults: UserDefaults(suiteName: "group.uk.co.inseven.bookmarks")!)
 
@@ -64,6 +73,12 @@ final public class Settings: ObservableObject {
         }
     }
 
+    @Published public var librarySections: [LibrarySection] {
+        didSet {
+            defaults.set(librarySections, forKey: .librarySections)
+        }
+    }
+
     public var user: String? {
         return pinboardApiKey?.components(separatedBy: ":").first
     }
@@ -78,6 +93,14 @@ final public class Settings: ObservableObject {
         maximumConcurrentThumbnailDownloads = defaults.integer(forKey: .maximumConcurrentThumbnailDownloads, default: 3)
         favoriteTags = defaults.object(forKey: .favoriteTags) as? [String] ?? []
         topTagsCount = defaults.integer(forKey: .topTagsCount, default: 5)
+        librarySections = defaults.object(forKey: .librarySections) as? [LibrarySection] ?? [
+            LibrarySection(section: .all, isEnabled: true),
+            LibrarySection(section: .unread, isEnabled: true),
+            LibrarySection(section: .today, isEnabled: true),
+            LibrarySection(section: .shared(true), isEnabled: true),
+            LibrarySection(section: .shared(false), isEnabled: true),
+            LibrarySection(section: .untagged, isEnabled: true),
+        ]
     }
 
     public func layoutMode(for section: BookmarksSection) -> LayoutMode {

--- a/core/Sources/BookmarksCore/Common/SettingsKey.swift
+++ b/core/Sources/BookmarksCore/Common/SettingsKey.swift
@@ -30,6 +30,7 @@ public enum SettingsKey: RawRepresentable {
     case layoutMode(BookmarksSection)
     case topTagsCount
     case showSectionCounts
+    case librarySections
 
     static let layoutModePrefix = "layout-mode-"
 
@@ -49,6 +50,8 @@ public enum SettingsKey: RawRepresentable {
             self = .topTagsCount
         case "show-section-counts":
             self = .showSectionCounts
+        case "library-sections":
+            self = .librarySections
         case _ where rawValue.starts(with: Self.layoutModePrefix):
             let rawSection = String(rawValue.dropFirst(Self.layoutModePrefix.count))
             guard let section = BookmarksSection(rawValue: rawSection) else {
@@ -78,6 +81,8 @@ public enum SettingsKey: RawRepresentable {
             return "show-section-counts"
         case .layoutMode(let section):
             return "\(Self.layoutModePrefix)\(section.rawValue)"
+        case .librarySections:
+            return "library-sections"
         }
     }
 }

--- a/core/Sources/BookmarksCore/Extensions/Scene.swift
+++ b/core/Sources/BookmarksCore/Extensions/Scene.swift
@@ -30,7 +30,7 @@ extension Scene {
 
             AccountCommands(applicationModel: applicationModel)
             ApplicationCommands()
-            SectionCommands()
+            SectionCommands(settings: applicationModel.settings)
             ViewCommands()
             BookmarkCommands()
 

--- a/core/Sources/BookmarksCore/Views/SidebarContentView.swift
+++ b/core/Sources/BookmarksCore/Views/SidebarContentView.swift
@@ -54,8 +54,8 @@ public struct SidebarContentView: View {
                 }
             }
             Section("Library") {
-                ForEach(BookmarksSection.defaultSections) { section in
-                    SectionLink(section: section)
+                ForEach(settings.librarySections) { librarySection in
+                    SectionLink(section: librarySection.section)
                 }
             }
             if !settings.favoriteTags.isEmpty {


### PR DESCRIPTION
This change prioritises the 'Read Later' and 'Today' sections.