### PR TITLE
fix: Prefer platform provided titles in the share extension

### DIFF
--- a/ios/Bookmarks Share Extension/Model/ShareExtensionModel.swift
+++ b/ios/Bookmarks Share Extension/Model/ShareExtensionModel.swift
@@ -62,8 +62,14 @@ class ShareExtensionModel: ObservableObject, Runnable {
         tagsModel.start()
     }
 
+    func title(for url: URL, preferredTitle: String?) async throws -> String {
+        if let preferredTitle {
+            return preferredTitle
+        }
+        return try await url.title() ?? ""
+    }
+
     @MainActor func load() {
-        dispatchPrecondition(condition: .onQueue(.main))
         guard let extensionItem = dataSource?.extensionContext?.inputItems.first as? NSExtensionItem,
               let attachment = extensionItem.attachments?.first
         else {
@@ -79,7 +85,7 @@ class ShareExtensionModel: ObservableObject, Runnable {
                         self.post = post
                     }
                 } else {
-                    let title = try await url.title() ?? ""
+                    let title = try await title(for: url, preferredTitle: extensionItem.attributedContentText?.string)
                     await MainActor.run {
                         self.post = Pinboard.Post(href: url, description: title, time: nil)
                     }


### PR DESCRIPTION
iOS and macOS will often propose a title alongside the URL when sharing an item to the share extension. This change prefers that title if it's present to reduce the reliance on fetching the titles ourselves (which can be unreliable if we're only fetching the page contents and not going through the full page load in a browser).