### PR TITLE
ci: Update builds for Xcode 15

### DIFF
--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>destination</key>
+	<string>export</string>
+	<key>manageAppVersionAndBuildNumber</key>
+	<false/>
+	<key>method</key>
+	<string>app-store</string>
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>uk.co.inseven.bookmarks.new</key>
@@ -9,18 +15,14 @@
 		<key>uk.co.inseven.bookmarks.new.ShareExtension</key>
 		<string>Bookmarks Share Extension App Store Profile</string>
 	</dict>
-	<key>destination</key>
-	<string>export</string>
-	<key>method</key>
-	<string>app-store</string>
+	<key>signingCertificate</key>
+	<string>2AEA1234843D262A1F540E2F27DCC258932B0F57</string>
 	<key>signingStyle</key>
-	<string>automatic</string>
+	<string>manual</string>
 	<key>stripSwiftSymbols</key>
 	<true/>
 	<key>teamID</key>
 	<string>S4WXAUZQEV</string>
-	<key>uploadBitcode</key>
-	<false/>
 	<key>uploadSymbols</key>
 	<true/>
 </dict>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -72,7 +72,7 @@ done
 
 # iPhone to be used for smoke test builds and tests.
 # This doesn't specify the OS version to allow the build script to recover from minor build changes.
-IPHONE_DESTINATION="platform=iOS Simulator,name=iPhone 14 Pro"
+IPHONE_DESTINATION="platform=iOS Simulator,name=iPhone 15 Pro"
 
 # Generate a random string to secure the local keychain.
 export TEMPORARY_KEYCHAIN_PASSWORD=`openssl rand -base64 14`

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -114,6 +114,7 @@ popd
 # Test iOS and macOS.
 
 # iOS
+xcrun simctl list devices
 sudo xcode-select --switch "$IOS_XCODE_PATH"
 build_scheme "Bookmarks iOS" clean build build-for-testing test \
     -sdk iphonesimulator \


### PR DESCRIPTION
This updates tests to target the iPhone 15 simulator and updates the iOS export options to explicitly reference the signing certificate.