### PR TITLE
fix: Update Interact version and license

### DIFF
--- a/Bookmarks.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bookmarks.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/scinfu/SwiftSoup.git",
         "state": {
           "branch": null,
-          "revision": "8b6cf29eead8841a1fa7822481cb3af4ddaadba6",
-          "version": "2.6.1"
+          "revision": "f83c097597094a04124eb6e0d1e894d24129af87",
+          "version": "2.7.0"
         }
       },
       {
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/ksemianov/WrappingHStack.git",
         "state": {
           "branch": "main",
-          "revision": "7b48e1f19d337cf934d725bff54cac9519e285d8",
+          "revision": "3300f68b6bf5f8a75ee7ca8a40f136a558053d10",
           "version": null
         }
       }

--- a/core/Sources/BookmarksCore/Common/Legal.swift
+++ b/core/Sources/BookmarksCore/Common/Legal.swift
@@ -21,6 +21,7 @@
 import Foundation
 
 import Diligence
+import Interact
 
 public struct Legal {
 
@@ -44,7 +45,7 @@ public struct Legal {
     } licenses: {
         License("Bookmarks", author: "Jason Morley", filename: "bookmarks-license", bundle: .module)
         License("HashRainbow", author: "Sarah Barbour", filename: "hashrainbow-license", bundle: .module)
-        License("Interact", author: "InSeven Limited", filename: "interact-license", bundle: .module)
+        License.interact
         License("SelectableCollectionView", author: "Jason Morley", filename: "selectablecollectionview-license", bundle: .module)
         License("Swift Algorithm Club", author: "Matthijs Hollemans and Contributors", filename: "swift-algorithm-club-license", bundle: .module)
         License("SwiftSoup", author: "Nabil Chatbi", filename: "swiftsoup-license", bundle: .module)

--- a/core/Sources/BookmarksCore/Common/Legal.swift
+++ b/core/Sources/BookmarksCore/Common/Legal.swift
@@ -45,7 +45,7 @@ public struct Legal {
     } licenses: {
         License("Bookmarks", author: "Jason Morley", filename: "bookmarks-license", bundle: .module)
         License("HashRainbow", author: "Sarah Barbour", filename: "hashrainbow-license", bundle: .module)
-        License.interact
+        License(Interact.Package.name, author: Interact.Package.author, url: Interact.Package.licenseURL)
         License("SelectableCollectionView", author: "Jason Morley", filename: "selectablecollectionview-license", bundle: .module)
         License("Swift Algorithm Club", author: "Matthijs Hollemans and Contributors", filename: "swift-algorithm-club-license", bundle: .module)
         License("SwiftSoup", author: "Nabil Chatbi", filename: "swiftsoup-license", bundle: .module)


### PR DESCRIPTION
This change also includes a drive-by fix to update some Swift dependencies.