### PR TITLE
fix: Crash on first run on macOS

### DIFF
--- a/core/Sources/BookmarksCore/Views/MacSectionGridView.swift
+++ b/core/Sources/BookmarksCore/Views/MacSectionGridView.swift
@@ -65,6 +65,7 @@ public struct MacSectionGridView: View {
             }
             return false
         }
+        .frame(minWidth: 640, minHeight: 480)
     }
 
 }


### PR DESCRIPTION
This is a work around for a possible issue in `SelectableCollectionView` (see https://github.com/inseven/SelectableCollectionView/issues/26) which was leading to a crash on first run when the default window frame hadn't been set. This change explicitly sets the minimum size of the collection view to 640x480 which hopefully isn't _too_ large for users with smaller screens.